### PR TITLE
Adding legend text size specs

### DIFF
--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -60,6 +60,10 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
       legend.position = "top",
       legend.text.align = 0,
       legend.background = ggplot2::element_blank(),
+      legend.text = ggplot2::element_text(family = cmapplot_globals$font_main,
+                                          face = cmapplot_globals$font_main_face,
+                                          size = 8,
+                                          color="#222222"),
       legend.title = ggplot2::element_blank(),
       legend.key = ggplot2::element_blank(),
 


### PR DESCRIPTION
Add new code to specify legend text size (8) - @matthewstern let me know if this is somehow related to your exploration of sizes (i.e., does 8 correspond to 8 pt font?)