### PR TITLE
Theme cmap sizing

### DIFF
--- a/R/cmapplot.R
+++ b/R/cmapplot.R
@@ -105,3 +105,36 @@ check_cmap_fonts <- function() {
   graphics::text(1, 1, "font_label", cex=4)
 }
 #check_cmap_fonts()
+
+
+# Helper function to calculate correct size for ggplot inputs. Takes two inputs:
+#  a value (numeric) and a type (character). The type can be "pt", "mm", or "in",
+#  representing points, millimeters, or inches, respectively.
+line_size_conversion <- function(value,type) {
+  if (type == "pt") {
+    output <- value /
+      ggplot2::.pt / # Account for ggplot's multiplication of size by .pt,
+                     #  which is defined as 72.27/25.4
+      72 * # Normalize from points
+      96 # Multiply by units for R pixels (per inch)
+  }
+  else if (type == "mm"){
+    output <-
+      value /
+      ggplot2::.pt / # Account for .pt
+      25.4 * # Normalize from millimeters
+      96 # Multiply by units for R pixels (per inch)
+  }
+  else if (type == "in") {
+    output <-
+      value /
+      ggplot2::.pt * # Account for .pt
+      96 # Multiply by units for R pixels (per inch)
+  }
+  else {
+    message("WARNING: Invalid value type")
+    return()
+  }
+
+  return(output)
+}

--- a/R/cmapplot.R
+++ b/R/cmapplot.R
@@ -24,7 +24,8 @@
 cmapplot_globals <- new.env(parent=emptyenv())  # An environment for storing any global variables
 
 
-### Default font handling -------------------------------------------
+# Default font handling ---------------------------------------------------
+
 if (.Platform$OS.type == "windows") {
 
   # Set CMAP fonts: use Whitney if installed, Calibri otherwise
@@ -109,39 +110,26 @@ check_cmap_fonts <- function() {
 #check_cmap_fonts()
 
 
-### plot sizes and colors  ------------------------------------------------
+# Plot sizes and colors ---------------------------------------------------
 
 # Helper function to calculate correct size for ggplot inputs. Takes two inputs:
-#  a value (numeric) and a type (character). The type can be "pt", "mm", or "in",
-#  representing points, millimeters, or inches, respectively.
-line_size_conversion <- function(value,type) {
-  if (type == "pt" | type == "mm" | type == "in") {
-    points_value <- grid::convertUnit(unit(value,type), # Take inputs
-                                      "points", # convert to points
-                                      valueOnly = TRUE) # Drop units
-  }
-
-  else {
-    message("WARNING: Invalid value type")
-    return()
-  }
-
-  output <-
-    points_value /
-    72 * # Normalize from points
-    96 / # Multiply by units for R pixels (per inch)
-    ggplot2::.pt # Account for ggplot's multiplication of size by .pt,
-                 #  which is defined as 72.27/25.4
-
-  return(output)
+# a value (numeric) and a type (character). The type can be any of the units
+# accepted by `grid::unit()`, including "pt", "mm", and "in".
+ggplot_size_conversion <- function(value, type) {
+    value_in_pt <- grid::convertUnit(grid::unit(value, type), "points", valueOnly = TRUE)
+    return(
+      value_in_pt / 72.27  # Normalize from points
+        * 96               # Multiply by units for R pixels (per inch)
+        / ggplot2::.pt     # Account for the ggplot2::.pt factor (=72.27/25.4)
+    )
 }
 
-
 # Pre-set values for width of lines (specified by the Communications team)
+cmapplot_globals$lwd_layout  <- ggplot_size_conversion(3, "pt")
+cmapplot_globals$wd_origin <- ggplot_size_conversion(1.6, "pt") # This is not spec, but appears to be the minimum for variation between origin lines and other background lines
+cmapplot_globals$lwd_other <- ggplot_size_conversion(.3, "pt")
 
-cmapplot_globals$line_graph_width  <- line_size_conversion(3, "pt")
-cmapplot_globals$origin_line_width <- line_size_conversion(1.6, "pt") # This is not spec, but appears to be the minimum for variation between origin lines and other background lines
-cmapplot_globals$other_line_width  <- line_size_conversion(.3, "pt")
-cmapplot_globals$black_hex         <- "#222222"
-
-
+# Define common colors
+cmapplot_globals$colors <- list(
+  blackish = "#222222"
+)

--- a/R/cmapplot.R
+++ b/R/cmapplot.R
@@ -23,6 +23,8 @@
 
 cmapplot_globals <- new.env(parent=emptyenv())  # An environment for storing any global variables
 
+
+### Default font handling -------------------------------------------
 if (.Platform$OS.type == "windows") {
 
   # Set CMAP fonts: use Whitney if installed, Calibri otherwise
@@ -107,6 +109,8 @@ check_cmap_fonts <- function() {
 #check_cmap_fonts()
 
 
+### plot sizes and colors  ------------------------------------------------
+
 # Helper function to calculate correct size for ggplot inputs. Takes two inputs:
 #  a value (numeric) and a type (character). The type can be "pt", "mm", or "in",
 #  representing points, millimeters, or inches, respectively.
@@ -127,13 +131,17 @@ line_size_conversion <- function(value,type) {
     72 * # Normalize from points
     96 / # Multiply by units for R pixels (per inch)
     ggplot2::.pt # Account for ggplot's multiplication of size by .pt,
-                 #  which is defined as 72.27/25.4
+  #  which is defined as 72.27/25.4
 
   return(output)
 }
 
+
 # Pre-set values for width of lines (specified by the Communications team)
 
-line_graph_width  <- line_size_conversion(3, "pt")
-origin_line_width <- line_size_conversion(1.6, "pt") # This is not spec, but appears to be the minimum for variation between origin lines and other background lines
-other_line_width  <- line_size_conversion(.3, "pt")
+cmapplot_globals$line_graph_width  <- line_size_conversion(3, "pt")
+cmapplot_globals$origin_line_width <- line_size_conversion(1.6, "pt") # This is not spec, but appears to be the minimum for variation between origin lines and other background lines
+cmapplot_globals$other_line_width  <- line_size_conversion(.3, "pt")
+cmapplot_globals$black_hex         <- "#222222"
+
+

--- a/R/cmapplot.R
+++ b/R/cmapplot.R
@@ -131,7 +131,7 @@ line_size_conversion <- function(value,type) {
     72 * # Normalize from points
     96 / # Multiply by units for R pixels (per inch)
     ggplot2::.pt # Account for ggplot's multiplication of size by .pt,
-  #  which is defined as 72.27/25.4
+                 #  which is defined as 72.27/25.4
 
   return(output)
 }

--- a/R/cmapplot.R
+++ b/R/cmapplot.R
@@ -126,7 +126,7 @@ ggplot_size_conversion <- function(value, type) {
 
 # Pre-set values for width of lines (specified by the Communications team)
 cmapplot_globals$lwd_layout  <- ggplot_size_conversion(3, "pt")
-cmapplot_globals$wd_origin <- ggplot_size_conversion(1.6, "pt") # This is not spec, but appears to be the minimum for variation between origin lines and other background lines
+cmapplot_globals$lwd_origin <- ggplot_size_conversion(1.6, "pt") # This is not spec, but appears to be the minimum for variation between origin lines and other background lines
 cmapplot_globals$lwd_other <- ggplot_size_conversion(.3, "pt")
 
 # Define common colors

--- a/R/cmapplot.R
+++ b/R/cmapplot.R
@@ -111,30 +111,29 @@ check_cmap_fonts <- function() {
 #  a value (numeric) and a type (character). The type can be "pt", "mm", or "in",
 #  representing points, millimeters, or inches, respectively.
 line_size_conversion <- function(value,type) {
-  if (type == "pt") {
-    output <- value /
-      ggplot2::.pt / # Account for ggplot's multiplication of size by .pt,
-                     #  which is defined as 72.27/25.4
-      72 * # Normalize from points
-      96 # Multiply by units for R pixels (per inch)
+  if (type == "pt" | type == "mm" | type == "in") {
+    points_value <- grid::convertUnit(unit(value,type), # Take inputs
+                                      "points", # convert to points
+                                      valueOnly = TRUE) # Drop units
   }
-  else if (type == "mm"){
-    output <-
-      value /
-      ggplot2::.pt / # Account for .pt
-      25.4 * # Normalize from millimeters
-      96 # Multiply by units for R pixels (per inch)
-  }
-  else if (type == "in") {
-    output <-
-      value /
-      ggplot2::.pt * # Account for .pt
-      96 # Multiply by units for R pixels (per inch)
-  }
+
   else {
     message("WARNING: Invalid value type")
     return()
   }
 
+  output <-
+    points_value /
+    72 * # Normalize from points
+    96 / # Multiply by units for R pixels (per inch)
+    ggplot2::.pt # Account for ggplot's multiplication of size by .pt,
+                 #  which is defined as 72.27/25.4
+
   return(output)
 }
+
+# Pre-set values for width of lines (specified by the Communications team)
+
+line_graph_width  <- line_size_conversion(3, "pt")
+origin_line_width <- line_size_conversion(1.6, "pt") # This is not spec, but appears to be the minimum for variation between origin lines and other background lines
+other_line_width  <- line_size_conversion(.3, "pt")

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -44,13 +44,13 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
       # Default text
       text = ggplot2::element_text(family = cmapplot_globals$font_main,
                                    face = cmapplot_globals$font_main_face,
-                                   size = 12,
+                                   size = 14,
                                    color="#222222"),
 
       # Title text
       plot.title = ggplot2::element_text(family=cmapplot_globals$font_title,
                                          face=cmapplot_globals$font_title_face,
-                                         size=14),
+                                         size=17),
 
       # Text elements not displayed
       plot.subtitle = ggplot2::element_blank(),
@@ -60,10 +60,7 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
       legend.position = "top",
       legend.text.align = 0,
       legend.background = ggplot2::element_blank(),
-      legend.text = ggplot2::element_text(family = cmapplot_globals$font_main,
-                                          face = cmapplot_globals$font_main_face,
-                                          size = 14,
-                                          color="#222222"),
+      legend.text = ggplot2::element_text(),
       legend.title = ggplot2::element_blank(),
       legend.key = ggplot2::element_blank(),
 
@@ -85,7 +82,7 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
       strip.background = ggplot2::element_rect(fill="white"),
 
       #Facet wrap text
-      strip.text = ggplot2::element_text(size  = 12,  hjust = 0)
+      strip.text = ggplot2::element_text(hjust = 0)
     ),
 
     # The following elements get added based on the presence of specific

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -62,7 +62,7 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
       legend.background = ggplot2::element_blank(),
       legend.text = ggplot2::element_text(family = cmapplot_globals$font_main,
                                           face = cmapplot_globals$font_main_face,
-                                          size = 8,
+                                          size = 11,
                                           color="#222222"),
       legend.title = ggplot2::element_blank(),
       legend.key = ggplot2::element_blank(),

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -11,9 +11,9 @@
 #'@param hline,vline Numeric, the location of a strong horizontal or vertical
 #'  line to be added to the plot. Use \code{hline = 0}, for example, to place a
 #'  line at y = 0 to differentiate between positive and negative values.
-#'@param ygrid,xgrid Bool, the display of vertical and/or horizontal grid lines
-#'  on the chart. If left as default, horizontal grid lines will be displayed
-#'  while vertical grid lines will be masked.
+#' @param gridlines Char, the grid lines to be displayed on the chart. If left
+#'   as default, horizontal grid lines will be displayed while vertical grid
+#'   lines will be masked.
 #'
 #'@examples
 #'
@@ -29,15 +29,15 @@
 #'    scale_y_continuous(labels = scales::percent) +
 #'    theme_cmap(hline = 0, ylab = "This is the y axis")
 #'
-#' ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
+#'  ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
 #'    geom_col(position = position_stack(reverse = TRUE)) +
 #'    coord_flip() +
 #'    scale_y_continuous(labels = scales::percent) +
-#'    theme_cmap(hline = 0, ygrid = FALSE, xgrid = TRUE)
+#'    theme_cmap(hline = 0, gridlines = "v")
 #' }
 #'@export
 theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
-                       ygrid = TRUE, xgrid = FALSE) {
+                       gridlines = c("h","v","vh",NA)) {
 
   # Generate an explicit message to user if Whitney font family is not available
   if (!(cmapplot_globals$use_whitney)){
@@ -125,22 +125,22 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
     },
 
     # Adjust grid lines
-    if (ygrid) {
+    if ("h" == gridlines | "vh" == gridlines) {
       ggplot2::theme(panel.grid.major.y =
                        ggplot2::element_line(size = other_line_width,
                                              color="#222222"))
-    },
-    if (!ygrid) {
+    }
+    else {
       ggplot2::theme(panel.grid.major.y = ggplot2::element_blank())
     },
 
-    if (xgrid) {
+    if ("v" == gridlines | "vh" == gridlines) {
       ggplot2::theme(panel.grid.major.x =
                        ggplot2::element_line(size = other_line_width,
                                              color="#222222"))
-    },
-    if (!xgrid) {
-      ggplot2::theme(panel.grid.major.y = ggplot2::element_blank())
+    }
+    else {
+      ggplot2::theme(panel.grid.major.x = ggplot2::element_blank())
     }
   )
 

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -75,7 +75,7 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
       axis.line = ggplot2::element_blank(),
 
       #Grid lines
-      panel.grid.major.y = ggplot2::element_line(color="#cbcbcb"),
+      panel.grid.major.y = ggplot2::element_line(size = 0.140359, color="#222222"),
       panel.grid.major.x = ggplot2::element_blank(),
 
       #Blank background
@@ -110,12 +110,12 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
 
     # add x origin line if specified
     if(!is.null(hline)){
-      ggplot2::geom_hline(yintercept = hline, size = 1, color = "#222222")
+      ggplot2::geom_hline(yintercept = hline, size = 0.4656139, color = "#222222")
     },
 
     # add y origin line if specified
     if(!is.null(vline)){
-      ggplot2::geom_vline(xintercept = vline, size = 1, color = "#222222")
+      ggplot2::geom_vline(xintercept = vline, size = 0.4656139, color = "#222222")
     }
   )
 

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -44,6 +44,8 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
     message("'Whitney' font family not found. Using a substitute...")
   }
 
+  match.arg(gridlines)
+
   # Generate list of elements to return.
   elements <- list(
 

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -3,7 +3,7 @@
 #'\code{theme_cmap} returns one or more ggplot objects that together construct a
 #'plot area in accordance with CMAP design standards.
 #'
-#'@usage theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL, gridlines = c("h","v","vh",NA))
+#'@usage theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL, gridlines = c("h","v","vh","none"))
 #'
 #'@param xlab,ylab Char, the string used to label the x and y axes,
 #'  respectively. If left as NULL, the default, the axis label will be left off
@@ -13,7 +13,8 @@
 #'  line at y = 0 to differentiate between positive and negative values.
 #' @param gridlines Char, the grid lines to be displayed on the chart. If left
 #'   as default, horizontal grid lines will be displayed while vertical grid
-#'   lines will be masked.
+#'   lines will be masked. Acceptable values are "v" (vertical), "h"
+#'   (horizontal), "vh" (both), and "none" (none).
 #'
 #'@examples
 #'
@@ -37,14 +38,14 @@
 #' }
 #'@export
 theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
-                       gridlines = c("h","v","vh",NA)) {
+                       gridlines = c("h","v","vh","none")) {
 
   # Generate an explicit message to user if Whitney font family is not available
   if (!(cmapplot_globals$use_whitney)){
     message("'Whitney' font family not found. Using a substitute...")
   }
 
-  match.arg(gridlines)
+  match.arg(gridlines) # Check if gridline input is allowed, throws error if not
 
   # Generate list of elements to return.
   elements <- list(

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -72,7 +72,8 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
       axis.line = ggplot2::element_blank(),
 
       #Grid lines
-      panel.grid.major.y = ggplot2::element_line(size = 0.140359, color="#222222"),
+      panel.grid.major.y = ggplot2::element_line(size = other_line_width,
+                                                 color="#222222"),
       panel.grid.major.x = ggplot2::element_blank(),
 
       #Blank background
@@ -107,12 +108,16 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
 
     # add x origin line if specified
     if(!is.null(hline)){
-      ggplot2::geom_hline(yintercept = hline, size = 0.4656139, color = "#222222")
+      ggplot2::geom_hline(yintercept = hline,
+                          size = origin_line_width,
+                          color="#222222")
     },
 
     # add y origin line if specified
     if(!is.null(vline)){
-      ggplot2::geom_vline(xintercept = vline, size = 0.4656139, color = "#222222")
+      ggplot2::geom_vline(xintercept = vline,
+                          size = origin_line_width,
+                          color = "#222222")
     }
   )
 

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -19,10 +19,14 @@
 #'@examples
 #'
 #'\dontrun{
+#'
+#' # The only way to place the origin line (`hline`, `vline`) behind any data geoms
+#' # is to or place `theme_cmap()` before the geoms:
 #'  ggplot(grp_over_time, aes(x = year, y = realgrp, color = cluster)) +
+#'    theme_cmap(hline = 0, ylab = "Percent change") +
 #'    geom_line() +
-#'    scale_x_continuous(breaks = scales::breaks_pretty(11)) +
-#'    theme_cmap(hline = 0, ylab = "Percent change")
+#'    scale_x_continuous(breaks = scales::breaks_pretty(11))
+#'
 #'
 #'  df <- dplyr::filter(traded_emp_by_race, variable %in% c("SpecializedTraded",
 #'    "UnspecializedTraded"))
@@ -63,7 +67,7 @@ theme_cmap <- function(
       text = ggplot2::element_text(family = cmapplot_globals$font_main,
                                    face = cmapplot_globals$font_main_face,
                                    size = 14,
-                                   color="#222222"),
+                                   color=cmapplot_globals$black_hex),
 
       # Title text
       plot.title = ggplot2::element_text(family=cmapplot_globals$font_title,
@@ -128,30 +132,30 @@ theme_cmap <- function(
     # add x origin line if specified
     if(!is.null(hline)){
       ggplot2::geom_hline(yintercept = hline,
-                          size = origin_line_width,
-                          color="#222222")
+                          size = cmapplot_globals$origin_line_width,
+                          color=cmapplot_globals$black_hex)
     },
 
     # add y origin line if specified
     if(!is.null(vline)){
       ggplot2::geom_vline(xintercept = vline,
-                          size = origin_line_width,
-                          color = "#222222")
+                          size = cmapplot_globals$origin_line_width,
+                          color = cmapplot_globals$black_hex)
     },
 
     # re-introduce horizontal gridlines if specified
     if (grepl("h", gridlines)) {
       ggplot2::theme(
-        panel.grid.major.y = ggplot2::element_line(size = other_line_width,
-                                                   color = "#222222")
+        panel.grid.major.y = ggplot2::element_line(size = cmapplot_globals$other_line_width,
+                                                   color = cmapplot_globals$black_hex)
       )
     },
 
     # re-introduce vertical gridlines if specified
     if (grepl("v", gridlines)) {
       ggplot2::theme(
-        panel.grid.major.x = ggplot2::element_line(size = other_line_width,
-                                                   color = "#222222")
+        panel.grid.major.x = ggplot2::element_line(size = cmapplot_globals$other_line_width,
+                                                   color = cmapplot_globals$black_hex)
       )
     }
   )

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -62,7 +62,7 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
       legend.background = ggplot2::element_blank(),
       legend.text = ggplot2::element_text(family = cmapplot_globals$font_main,
                                           face = cmapplot_globals$font_main_face,
-                                          size = 11,
+                                          size = 14,
                                           color="#222222"),
       legend.title = ggplot2::element_blank(),
       legend.key = ggplot2::element_blank(),

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -4,7 +4,7 @@
 #'plot area in accordance with CMAP design standards.
 #'
 #'@usage theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
-#'  gridlines = c("h","v","hv","none"))
+#'  gridlines = c("h", "v", "hv", "none"))
 #'
 #'@param xlab,ylab Char, the string used to label the x and y axes,
 #'  respectively. If unspecified, the axis label will be left off the graph.
@@ -46,11 +46,11 @@
 theme_cmap <- function(
   xlab = NULL, ylab = NULL,
   hline = NULL, vline = NULL,
-  gridlines = c("h","v","hv","none")
+  gridlines = c("h", "v", "hv", "none")
 ) {
 
   # Generate an explicit message to user if Whitney font family is not available
-  if (!(cmapplot_globals$use_whitney)){
+  if (!(cmapplot_globals$use_whitney)) {
     message("'Whitney' font family not found. Using a substitute...")
   }
 
@@ -67,18 +67,18 @@ theme_cmap <- function(
       text = ggplot2::element_text(family = cmapplot_globals$font_main,
                                    face = cmapplot_globals$font_main_face,
                                    size = 14,
-                                   color=cmapplot_globals$black_hex),
+                                   color = cmapplot_globals$colors$blackish),
 
       # Title text
-      plot.title = ggplot2::element_text(family=cmapplot_globals$font_title,
-                                         face=cmapplot_globals$font_title_face,
-                                         size=17),
+      plot.title = ggplot2::element_text(family = cmapplot_globals$font_title,
+                                         face = cmapplot_globals$font_title_face,
+                                         size = 17),
 
       # Text elements not displayed
       plot.subtitle = ggplot2::element_blank(),
       plot.caption = ggplot2::element_blank(),
 
-      #Legend format
+      # Legend format
       legend.position = "top",
       legend.text.align = 0,
       legend.background = ggplot2::element_blank(),
@@ -86,26 +86,26 @@ theme_cmap <- function(
       legend.title = ggplot2::element_blank(),
       legend.key = ggplot2::element_blank(),
 
-      #Axis format
+      # Axis format
       axis.title.y = ggplot2::element_blank(),
       axis.title.x = ggplot2::element_blank(),
-      axis.text.x = ggplot2::element_text(margin=ggplot2::margin(5, b = 10)),
+      axis.text.x = ggplot2::element_text(margin = ggplot2::margin(5, b = 10)),
       axis.ticks = ggplot2::element_blank(),
       axis.line = ggplot2::element_blank(),
 
-      #Blank background
+      # Blank background
       panel.background = ggplot2::element_blank(),
 
-      #No gridlines
+      # No gridlines
       panel.grid.major.x = ggplot2::element_blank(),
       panel.grid.minor.x = ggplot2::element_blank(),
       panel.grid.major.y = ggplot2::element_blank(),
       panel.grid.minor.y = ggplot2::element_blank(),
 
-      #Strip background
-      strip.background = ggplot2::element_rect(fill="white"),
+      # Strip background
+      strip.background = ggplot2::element_rect(fill = "white"),
 
-      #Facet wrap text
+      # Facet wrap text
       strip.text = ggplot2::element_text(hjust = 0)
     ),
 
@@ -113,7 +113,7 @@ theme_cmap <- function(
     # function arguments. These elements add to or overwrite portions of
     # the default theme.
 
-    # re-introduce x label if specified
+    # Re-introduce x label, if specified
     if(!is.null(xlab)){
       ggplot2::theme(axis.title.x = element_text())
     },
@@ -121,7 +121,7 @@ theme_cmap <- function(
       ggplot2::xlab(xlab)
     },
 
-    # re-introduce y label if specified
+    # Re-introduce y label, if specified
     if(!is.null(ylab)){
       ggplot2::theme(axis.title.y = element_text())
     },
@@ -129,37 +129,37 @@ theme_cmap <- function(
       ggplot2::ylab(ylab)
     },
 
-    # add x origin line if specified
+    # Add x origin line, if specified
     if(!is.null(hline)){
       ggplot2::geom_hline(yintercept = hline,
-                          size = cmapplot_globals$origin_line_width,
-                          color=cmapplot_globals$black_hex)
+                          size = cmapplot_globals$lwd_origin,
+                          color = cmapplot_globals$colors$blackish)
     },
 
-    # add y origin line if specified
+    # Add y origin line, if specified
     if(!is.null(vline)){
       ggplot2::geom_vline(xintercept = vline,
-                          size = cmapplot_globals$origin_line_width,
-                          color = cmapplot_globals$black_hex)
+                          size = cmapplot_globals$lwd_origin,
+                          color = cmapplot_globals$colors$blackish)
     },
 
-    # re-introduce horizontal gridlines if specified
+    # Re-introduce horizontal gridlines if specified
     if (grepl("h", gridlines)) {
       ggplot2::theme(
-        panel.grid.major.y = ggplot2::element_line(size = cmapplot_globals$other_line_width,
-                                                   color = cmapplot_globals$black_hex)
+        panel.grid.major.y = ggplot2::element_line(size = cmapplot_globals$lwd_other,
+                                                   color = cmapplot_globals$colors$blackish)
       )
     },
 
-    # re-introduce vertical gridlines if specified
+    # Re-introduce vertical gridlines if specified
     if (grepl("v", gridlines)) {
       ggplot2::theme(
-        panel.grid.major.x = ggplot2::element_line(size = cmapplot_globals$other_line_width,
-                                                   color = cmapplot_globals$black_hex)
+        panel.grid.major.x = ggplot2::element_line(size = cmapplot_globals$lwd_other,
+                                                   color = cmapplot_globals$colors$blackish)
       )
     }
   )
 
-  # filter out NA elements before returning
+  # Filter out NA elements before returning
   return(magrittr::extract(elements, !is.na(elements)))
 }

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -3,7 +3,7 @@
 #'\code{theme_cmap} returns one or more ggplot objects that together construct a
 #'plot area in accordance with CMAP design standards.
 #'
-#'@usage theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL)
+#'@usage theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL, gridlines = c("h","v","vh",NA))
 #'
 #'@param xlab,ylab Char, the string used to label the x and y axes,
 #'  respectively. If left as NULL, the default, the axis label will be left off

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -125,7 +125,7 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
     },
 
     # Adjust grid lines
-    if ("h" == gridlines | "vh" == gridlines) {
+    if (grepl("h", gridlines)) {
       ggplot2::theme(panel.grid.major.y =
                        ggplot2::element_line(size = other_line_width,
                                              color="#222222"))
@@ -134,7 +134,7 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
       ggplot2::theme(panel.grid.major.y = ggplot2::element_blank())
     },
 
-    if ("v" == gridlines | "vh" == gridlines) {
+    if (grepl("v", gridlines)) {
       ggplot2::theme(panel.grid.major.x =
                        ggplot2::element_line(size = other_line_width,
                                              color="#222222"))

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -3,7 +3,8 @@
 #'\code{theme_cmap} returns one or more ggplot objects that together construct a
 #'plot area in accordance with CMAP design standards.
 #'
-#'@usage theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL, gridlines = c("h","v","vh","none"))
+#'@usage theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
+#'gridlines = c("h","v","vh","none"))
 #'
 #'@param xlab,ylab Char, the string used to label the x and y axes,
 #'  respectively. If left as NULL, the default, the axis label will be left off
@@ -24,7 +25,8 @@
 #'  scale_x_continuous(breaks = scales::breaks_pretty(11)) +
 #'  theme_cmap(hline = 0, ylab = "Percent change")
 #'
-#' df <- dplyr::filter(traded_emp_by_race, variable %in% c("SpecializedTraded", "UnspecializedTraded"))
+#' df <- dplyr::filter(traded_emp_by_race, variable %in% c("SpecializedTraded",
+#' "UnspecializedTraded"))
 #'  ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
 #'    geom_col(position = position_stack(reverse = TRUE)) +
 #'    scale_y_continuous(labels = scales::percent) +

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -4,29 +4,29 @@
 #'plot area in accordance with CMAP design standards.
 #'
 #'@usage theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
-#'gridlines = c("h","v","vh","none"))
+#'  gridlines = c("h","v","hv","none"))
 #'
 #'@param xlab,ylab Char, the string used to label the x and y axes,
-#'  respectively. If left as NULL, the default, the axis label will be left off
-#'  the graph.
+#'  respectively. If unspecified, the axis label will be left off the graph.
 #'@param hline,vline Numeric, the location of a strong horizontal or vertical
 #'  line to be added to the plot. Use \code{hline = 0}, for example, to place a
 #'  line at y = 0 to differentiate between positive and negative values.
-#' @param gridlines Char, the grid lines to be displayed on the chart. If left
-#'   as default, horizontal grid lines will be displayed while vertical grid
-#'   lines will be masked. Acceptable values are "v" (vertical), "h"
-#'   (horizontal), "vh" (both), and "none" (none).
+#'@param gridlines Char, the grid lines to be displayed on the chart. If left as
+#'  default, horizontal grid lines will be displayed while vertical grid lines
+#'  will be masked. Acceptable values are "h" (horizontal only), "v" (vertical
+#'  only), "hv" (both horizontal and vertical), and "none" (neither).
 #'
 #'@examples
 #'
-#' \dontrun{
-#' ggplot(grp_over_time, aes(x = year, y = realgrp, color = cluster)) +
-#'  geom_line() +
-#'  scale_x_continuous(breaks = scales::breaks_pretty(11)) +
-#'  theme_cmap(hline = 0, ylab = "Percent change")
+#'\dontrun{
+#'  ggplot(grp_over_time, aes(x = year, y = realgrp, color = cluster)) +
+#'    geom_line() +
+#'    scale_x_continuous(breaks = scales::breaks_pretty(11)) +
+#'    theme_cmap(hline = 0, ylab = "Percent change")
 #'
-#' df <- dplyr::filter(traded_emp_by_race, variable %in% c("SpecializedTraded",
-#' "UnspecializedTraded"))
+#'  df <- dplyr::filter(traded_emp_by_race, variable %in% c("SpecializedTraded",
+#'    "UnspecializedTraded"))
+#'
 #'  ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
 #'    geom_col(position = position_stack(reverse = TRUE)) +
 #'    scale_y_continuous(labels = scales::percent) +
@@ -39,15 +39,19 @@
 #'    theme_cmap(hline = 0, gridlines = "v")
 #' }
 #'@export
-theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
-                       gridlines = c("h","v","vh","none")) {
+theme_cmap <- function(
+  xlab = NULL, ylab = NULL,
+  hline = NULL, vline = NULL,
+  gridlines = c("h","v","hv","none")
+) {
 
   # Generate an explicit message to user if Whitney font family is not available
   if (!(cmapplot_globals$use_whitney)){
     message("'Whitney' font family not found. Using a substitute...")
   }
 
-  match.arg(gridlines) # Check if gridline input is allowed, throws error if not
+  # Validate gridlines parameter, throw error if invalid
+  gridlines <- match.arg(gridlines)
 
   # Generate list of elements to return.
   elements <- list(
@@ -87,6 +91,12 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
 
       #Blank background
       panel.background = ggplot2::element_blank(),
+
+      #No gridlines
+      panel.grid.major.x = ggplot2::element_blank(),
+      panel.grid.minor.x = ggplot2::element_blank(),
+      panel.grid.major.y = ggplot2::element_blank(),
+      panel.grid.minor.y = ggplot2::element_blank(),
 
       #Strip background
       strip.background = ggplot2::element_rect(fill="white"),
@@ -129,23 +139,20 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
                           color = "#222222")
     },
 
-    # Adjust grid lines
+    # re-introduce horizontal gridlines if specified
     if (grepl("h", gridlines)) {
-      ggplot2::theme(panel.grid.major.y =
-                       ggplot2::element_line(size = other_line_width,
-                                             color="#222222"))
-    }
-    else {
-      ggplot2::theme(panel.grid.major.y = ggplot2::element_blank())
+      ggplot2::theme(
+        panel.grid.major.y = ggplot2::element_line(size = other_line_width,
+                                                   color = "#222222")
+      )
     },
 
+    # re-introduce vertical gridlines if specified
     if (grepl("v", gridlines)) {
-      ggplot2::theme(panel.grid.major.x =
-                       ggplot2::element_line(size = other_line_width,
-                                             color="#222222"))
-    }
-    else {
-      ggplot2::theme(panel.grid.major.x = ggplot2::element_blank())
+      ggplot2::theme(
+        panel.grid.major.x = ggplot2::element_line(size = other_line_width,
+                                                   color = "#222222")
+      )
     }
   )
 

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -11,6 +11,9 @@
 #'@param hline,vline Numeric, the location of a strong horizontal or vertical
 #'  line to be added to the plot. Use \code{hline = 0}, for example, to place a
 #'  line at y = 0 to differentiate between positive and negative values.
+#'@param ygrid,xgrid Bool, the display of vertical and/or horizontal grid lines
+#'  on the chart. If left as default, horizontal grid lines will be displayed
+#'  while vertical grid lines will be masked.
 #'
 #'@examples
 #'
@@ -21,14 +24,20 @@
 #'  theme_cmap(hline = 0, ylab = "Percent change")
 #'
 #' df <- dplyr::filter(traded_emp_by_race, variable %in% c("SpecializedTraded", "UnspecializedTraded"))
-#' ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
-#'   geom_col(position = position_stack(reverse = TRUE)) +
-#'   scale_y_continuous(labels = scales::percent) +
-#'   theme_cmap(hline = 0, ylab = "This is the y axis")
-#' }
+#'  ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
+#'    geom_col(position = position_stack(reverse = TRUE)) +
+#'    scale_y_continuous(labels = scales::percent) +
+#'    theme_cmap(hline = 0, ylab = "This is the y axis")
 #'
+#' ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
+#'    geom_col(position = position_stack(reverse = TRUE)) +
+#'    coord_flip() +
+#'    scale_y_continuous(labels = scales::percent) +
+#'    theme_cmap(hline = 0, ygrid = FALSE, xgrid = TRUE)
+#' }
 #'@export
-theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
+theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
+                       ygrid = TRUE, xgrid = FALSE) {
 
   # Generate an explicit message to user if Whitney font family is not available
   if (!(cmapplot_globals$use_whitney)){
@@ -70,11 +79,6 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
       axis.text.x = ggplot2::element_text(margin=ggplot2::margin(5, b = 10)),
       axis.ticks = ggplot2::element_blank(),
       axis.line = ggplot2::element_blank(),
-
-      #Grid lines
-      panel.grid.major.y = ggplot2::element_line(size = other_line_width,
-                                                 color="#222222"),
-      panel.grid.major.x = ggplot2::element_blank(),
 
       #Blank background
       panel.background = ggplot2::element_blank(),
@@ -118,6 +122,25 @@ theme_cmap <- function(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL) {
       ggplot2::geom_vline(xintercept = vline,
                           size = origin_line_width,
                           color = "#222222")
+    },
+
+    # Adjust grid lines
+    if (ygrid) {
+      ggplot2::theme(panel.grid.major.y =
+                       ggplot2::element_line(size = other_line_width,
+                                             color="#222222"))
+    },
+    if (!ygrid) {
+      ggplot2::theme(panel.grid.major.y = ggplot2::element_blank())
+    },
+
+    if (xgrid) {
+      ggplot2::theme(panel.grid.major.x =
+                       ggplot2::element_line(size = other_line_width,
+                                             color="#222222"))
+    },
+    if (!xgrid) {
+      ggplot2::theme(panel.grid.major.y = ggplot2::element_blank())
     }
   )
 

--- a/man/theme_cmap.Rd
+++ b/man/theme_cmap.Rd
@@ -4,7 +4,7 @@
 \alias{theme_cmap}
 \title{Add CMAP theme to ggplot chart}
 \usage{
-theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL)
+theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL, gridlines = c("h","v","vh",NA))
 }
 \arguments{
 \item{xlab, ylab}{Char, the string used to label the x and y axes,

--- a/man/theme_cmap.Rd
+++ b/man/theme_cmap.Rd
@@ -27,10 +27,14 @@ plot area in accordance with CMAP design standards.
 \examples{
 
 \dontrun{
+
+# The only way to place the origin line (`hline`, `vline`) behind any data geoms
+# is to or place `theme_cmap()` before the geoms:
  ggplot(grp_over_time, aes(x = year, y = realgrp, color = cluster)) +
+   theme_cmap(hline = 0, ylab = "Percent change") +
    geom_line() +
-   scale_x_continuous(breaks = scales::breaks_pretty(11)) +
-   theme_cmap(hline = 0, ylab = "Percent change")
+   scale_x_continuous(breaks = scales::breaks_pretty(11))
+
 
  df <- dplyr::filter(traded_emp_by_race, variable \%in\% c("SpecializedTraded",
    "UnspecializedTraded"))

--- a/man/theme_cmap.Rd
+++ b/man/theme_cmap.Rd
@@ -4,7 +4,7 @@
 \alias{theme_cmap}
 \title{Add CMAP theme to ggplot chart}
 \usage{
-theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL, gridlines = c("h","v","vh",NA))
+theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL, gridlines = c("h","v","vh","none"))
 }
 \arguments{
 \item{xlab, ylab}{Char, the string used to label the x and y axes,
@@ -17,7 +17,8 @@ line at y = 0 to differentiate between positive and negative values.}
 
 \item{gridlines}{Char, the grid lines to be displayed on the chart. If left
 as default, horizontal grid lines will be displayed while vertical grid
-lines will be masked.}
+lines will be masked. Acceptable values are "v" (vertical), "h"
+(horizontal), "vh" (both), and "none" (none).}
 }
 \description{
 \code{theme_cmap} returns one or more ggplot objects that together construct a

--- a/man/theme_cmap.Rd
+++ b/man/theme_cmap.Rd
@@ -5,7 +5,7 @@
 \title{Add CMAP theme to ggplot chart}
 \usage{
 theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
- gridlines = c("h","v","hv","none"))
+ gridlines = c("h", "v", "hv", "none"))
 }
 \arguments{
 \item{xlab, ylab}{Char, the string used to label the x and y axes,

--- a/man/theme_cmap.Rd
+++ b/man/theme_cmap.Rd
@@ -14,6 +14,10 @@ the graph.}
 \item{hline, vline}{Numeric, the location of a strong horizontal or vertical
 line to be added to the plot. Use \code{hline = 0}, for example, to place a
 line at y = 0 to differentiate between positive and negative values.}
+
+\item{ygrid, xgrid}{Bool, the display of vertical and/or horizontal grid lines
+on the chart. If left as default, horizontal grid lines will be displayed
+while vertical grid lines will be masked.}
 }
 \description{
 \code{theme_cmap} returns one or more ggplot objects that together construct a
@@ -28,10 +32,15 @@ ggplot(grp_over_time, aes(x = year, y = realgrp, color = cluster)) +
  theme_cmap(hline = 0, ylab = "Percent change")
 
 df <- dplyr::filter(traded_emp_by_race, variable \%in\% c("SpecializedTraded", "UnspecializedTraded"))
-ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
-  geom_col(position = position_stack(reverse = TRUE)) +
-  scale_y_continuous(labels = scales::percent) +
-  theme_cmap(hline = 0, ylab = "This is the y axis")
-}
+ ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
+   geom_col(position = position_stack(reverse = TRUE)) +
+   scale_y_continuous(labels = scales::percent) +
+   theme_cmap(hline = 0, ylab = "This is the y axis")
 
+ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
+   geom_col(position = position_stack(reverse = TRUE)) +
+   coord_flip() +
+   scale_y_continuous(labels = scales::percent) +
+   theme_cmap(hline = 0, ygrid = FALSE, xgrid = TRUE)
+}
 }

--- a/man/theme_cmap.Rd
+++ b/man/theme_cmap.Rd
@@ -15,9 +15,9 @@ the graph.}
 line to be added to the plot. Use \code{hline = 0}, for example, to place a
 line at y = 0 to differentiate between positive and negative values.}
 
-\item{ygrid, xgrid}{Bool, the display of vertical and/or horizontal grid lines
-on the chart. If left as default, horizontal grid lines will be displayed
-while vertical grid lines will be masked.}
+\item{gridlines}{Char, the grid lines to be displayed on the chart. If left
+as default, horizontal grid lines will be displayed while vertical grid
+lines will be masked.}
 }
 \description{
 \code{theme_cmap} returns one or more ggplot objects that together construct a
@@ -37,10 +37,10 @@ df <- dplyr::filter(traded_emp_by_race, variable \%in\% c("SpecializedTraded", "
    scale_y_continuous(labels = scales::percent) +
    theme_cmap(hline = 0, ylab = "This is the y axis")
 
-ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
+ ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
    geom_col(position = position_stack(reverse = TRUE)) +
    coord_flip() +
    scale_y_continuous(labels = scales::percent) +
-   theme_cmap(hline = 0, ygrid = FALSE, xgrid = TRUE)
+   theme_cmap(hline = 0, gridlines = "v")
 }
 }

--- a/man/theme_cmap.Rd
+++ b/man/theme_cmap.Rd
@@ -5,21 +5,20 @@
 \title{Add CMAP theme to ggplot chart}
 \usage{
 theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
-gridlines = c("h","v","vh","none"))
+ gridlines = c("h","v","hv","none"))
 }
 \arguments{
 \item{xlab, ylab}{Char, the string used to label the x and y axes,
-respectively. If left as NULL, the default, the axis label will be left off
-the graph.}
+respectively. If unspecified, the axis label will be left off the graph.}
 
 \item{hline, vline}{Numeric, the location of a strong horizontal or vertical
 line to be added to the plot. Use \code{hline = 0}, for example, to place a
 line at y = 0 to differentiate between positive and negative values.}
 
-\item{gridlines}{Char, the grid lines to be displayed on the chart. If left
-as default, horizontal grid lines will be displayed while vertical grid
-lines will be masked. Acceptable values are "v" (vertical), "h"
-(horizontal), "vh" (both), and "none" (none).}
+\item{gridlines}{Char, the grid lines to be displayed on the chart. If left as
+default, horizontal grid lines will be displayed while vertical grid lines
+will be masked. Acceptable values are "h" (horizontal only), "v" (vertical
+only), "hv" (both horizontal and vertical), and "none" (neither).}
 }
 \description{
 \code{theme_cmap} returns one or more ggplot objects that together construct a
@@ -28,13 +27,14 @@ plot area in accordance with CMAP design standards.
 \examples{
 
 \dontrun{
-ggplot(grp_over_time, aes(x = year, y = realgrp, color = cluster)) +
- geom_line() +
- scale_x_continuous(breaks = scales::breaks_pretty(11)) +
- theme_cmap(hline = 0, ylab = "Percent change")
+ ggplot(grp_over_time, aes(x = year, y = realgrp, color = cluster)) +
+   geom_line() +
+   scale_x_continuous(breaks = scales::breaks_pretty(11)) +
+   theme_cmap(hline = 0, ylab = "Percent change")
 
-df <- dplyr::filter(traded_emp_by_race, variable \%in\% c("SpecializedTraded",
-"UnspecializedTraded"))
+ df <- dplyr::filter(traded_emp_by_race, variable \%in\% c("SpecializedTraded",
+   "UnspecializedTraded"))
+
  ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
    geom_col(position = position_stack(reverse = TRUE)) +
    scale_y_continuous(labels = scales::percent) +

--- a/man/theme_cmap.Rd
+++ b/man/theme_cmap.Rd
@@ -4,7 +4,8 @@
 \alias{theme_cmap}
 \title{Add CMAP theme to ggplot chart}
 \usage{
-theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL, gridlines = c("h","v","vh","none"))
+theme_cmap(xlab = NULL, ylab = NULL, hline = NULL, vline = NULL,
+gridlines = c("h","v","vh","none"))
 }
 \arguments{
 \item{xlab, ylab}{Char, the string used to label the x and y axes,
@@ -32,7 +33,8 @@ ggplot(grp_over_time, aes(x = year, y = realgrp, color = cluster)) +
  scale_x_continuous(breaks = scales::breaks_pretty(11)) +
  theme_cmap(hline = 0, ylab = "Percent change")
 
-df <- dplyr::filter(traded_emp_by_race, variable \%in\% c("SpecializedTraded", "UnspecializedTraded"))
+df <- dplyr::filter(traded_emp_by_race, variable \%in\% c("SpecializedTraded",
+"UnspecializedTraded"))
  ggplot(df, aes(x = reorder(Race, -value), y = value, fill = variable)) +
    geom_col(position = position_stack(reverse = TRUE)) +
    scale_y_continuous(labels = scales::percent) +


### PR DESCRIPTION
This pull request has three primary components related to the sizing and appearance of grid lines:

- The grid line modification addition to 'theme_cmap()' that we have been discussing in the comment thread. The way it operates now, the default is horizontal lines - but this can be changed with `gridlines = "v"` / `"vh"` / `NA`. There is also a new example that demonstrates this in action, which is a variant of the second example.
- Changes to line color for grid lines (from black to grey) to reflect current comms guidance.
- A new approach to `ggplot` sizes for line elements.

The first and last of these are the most substantial. Since the last one is less familiar, I wanted to walk through it here. 

After reviewing what's available online regarding `ggplot` line sizing (most importantly [this](https://stackoverflow.com/questions/17311917/ggplot2-the-unit-of-size) and [this](https://stackoverflow.com/questions/47519624/how-is-the-line-width-size-defined-in-ggplot2/47521808#47521808)), I wrote a new internal function (which lives in `cmapplot.R`) that can convert line widths in inches, millimeters, or points into the appropriate `ggplot` size for output. In other words, if you use the function on ".05 inches" it outputs the correct size value for `ggplot`. Unfortunately, and confusingly, this does not correspond simply to the weight of the line in points - it is off by a factor of ~2, for reasons outlined in the links above.

I do want to note that **this might not work the same on Mac machines** and it would be good to test it in multiple file types and environments. So far as I can tell, it works for png and pdf on Windows.

I used that function to define three new variables for line width, based on comms guidance, using the point equivalents of the inch-based measurements Matt [posted](https://github.com/CMAP-REPOS/cmapplot/issues/8#issuecomment-608441693) in the comment thread. I did have to modify the comms specification for the origin line, because it appears that `ggplot` does not have a great degree of variation in line size once you get to sufficiently small values (below what appears to be a lower bound of roughly 1.6 points). Where appropriate, I replaced numerically defined line sizes with the new variables. In the long term, I think it will be helpful to have a consolidated place for things like line sizes, so that they can be easily updated if and when comms guidance shifts.

For transparency in future work, this function and the variables it creates will also be helpful when incorporating line graph sizing functionality into the `finalize_plot` function.

Finally, this pull request also includes minor changes to overall font sizes, to reflect current comms guidance. This included a few eliminations of redundant code where font is specified in the overall `text` element of the theme and does not need to be re-specified in later sections.