### PR TITLE
Specify axis font colors

### DIFF
--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -89,6 +89,7 @@ theme_cmap <- function(
       # Axis format
       axis.title.y = ggplot2::element_blank(),
       axis.title.x = ggplot2::element_blank(),
+      axis.text = ggplot2::element_text(color = cmapplot_globals$colors$blackish),
       axis.text.x = ggplot2::element_text(margin = ggplot2::margin(5, b = 10)),
       axis.ticks = ggplot2::element_blank(),
       axis.line = ggplot2::element_blank(),


### PR DESCRIPTION
This appears to be required to change font colors for axis text.  Apparently, the axis text is not inheriting from the `text` element, which may be due to the reasons outlined [here](https://stackoverflow.com/questions/41006924/ggplot2-theme-axis-text-not-inheriting-from-text).