### PR TITLE
Midpoint setting

### DIFF
--- a/R/palettes_continuous.R
+++ b/R/palettes_continuous.R
@@ -111,13 +111,15 @@ mid_rescaler2 <- function(mid) {
     }
 }
 
-#' Apply continuous CMAP palettes to ggplot2 aesthetics
+#' Apply continuous CMAP palettes to ggplot2 aesthetics. On diverging palettes,
+#' a midpoint can be manually adjusted (defaults to 0)
 #'
-#' Pick the function depending on the aesthetic of your ggplot object (fill or color)
+#' Pick the function depending on the aesthetic of your ggplot object (fill or
+#' color)
 #'
-#' @param palette Choose from 'cmap_gradients' list
-#' @param reverse Logical; reverse color order?
-#' @param middle Numeric, sets midpoint for diverging color palettes. Default =
+#' @param palette String; Choose from 'cmap_gradients' list
+#' @param reverse Logical; Reverse color order?
+#' @param middle Numeric; Sets midpoint for diverging color palettes. Default =
 #'   0.
 #'
 #' @examples
@@ -133,10 +135,15 @@ mid_rescaler2 <- function(mid) {
 cmap_fill_continuous <- function(palette = "seq_reds",
                                  reverse = FALSE,
                                  middle = 0) {
-    ggplot2::scale_fill_gradientn(
-        colours = cmap_pal_continuous(palette, reverse = reverse)(256),
-        rescaler = mid_rescaler2(middle)
-    )
+    if (substr(palette,1,3) == "div") {
+        ggplot2::scale_fill_gradientn(
+            colours = cmap_pal_continuous(palette, reverse = reverse)(256),
+            rescaler = mid_rescaler2(middle)
+        )} else {
+            ggplot2::scale_fill_gradientn(
+                colours = cmap_pal_continuous(palette, reverse = reverse)(256)
+            )
+        }
 }
 
 
@@ -147,10 +154,15 @@ cmap_fill_continuous <- function(palette = "seq_reds",
 cmap_color_continuous <- function(palette = "seq_reds",
                                   reverse = FALSE,
                                   middle = 0) {
+    if (substr(palette,1,3) == "div") {
     ggplot2::scale_colour_gradientn(
         colours = cmap_pal_continuous(palette, reverse = reverse)(256),
         rescaler = mid_rescaler2(middle)
-    )
+    )} else {
+        ggplot2::scale_colour_gradientn(
+            colours = cmap_pal_continuous(palette, reverse = reverse)(256)
+        )
+    }
 }
 
 #' @describeIn cmap_fill_continuous For color aesthetic

--- a/R/palettes_continuous.R
+++ b/R/palettes_continuous.R
@@ -102,7 +102,14 @@ cmap_pal_continuous <- function(palette = "seq_reds", reverse = FALSE) {
     }
     return(grDevices::colorRampPalette(pal))
 }
-
+#' internal helper function to rescale. Credit for idea is due to ijlyttle:
+#  \url{https://github.com/tidyverse/ggplot2/issues/3738#issuecomment-583750802}
+#' @noRd
+mid_rescaler2 <- function(mid) {
+    function(x, to = c(0, 1), from = range(x, na.rm = TRUE)) {
+        scales::rescale_mid(x, to, from, mid)
+    }
+}
 
 #' Apply continuous CMAP palettes to ggplot2 aesthetics
 #'
@@ -110,6 +117,8 @@ cmap_pal_continuous <- function(palette = "seq_reds", reverse = FALSE) {
 #'
 #' @param palette Choose from 'cmap_gradients' list
 #' @param reverse Logical; reverse color order?
+#' @param middle Numeric, sets midpoint for diverging color palettes. Default =
+#'   0.
 #'
 #' @examples
 #' library(dplyr)
@@ -121,17 +130,26 @@ cmap_pal_continuous <- function(palette = "seq_reds", reverse = FALSE) {
 #'
 #' @describeIn cmap_fill_continuous For fill aesthetic
 #' @export
-cmap_fill_continuous <- function(palette = "seq_reds", reverse = FALSE) {
+cmap_fill_continuous <- function(palette = "seq_reds",
+                                 reverse = FALSE,
+                                 middle = 0) {
     ggplot2::scale_fill_gradientn(
-        colours = cmap_pal_continuous(palette, reverse = reverse)(256)
+        colours = cmap_pal_continuous(palette, reverse = reverse)(256),
+        rescaler = mid_rescaler2(middle)
     )
 }
 
+
+
+
 #' @describeIn cmap_fill_continuous For color aesthetic
 #' @export
-cmap_color_continuous <- function(palette = "seq_reds", reverse = FALSE) {
+cmap_color_continuous <- function(palette = "seq_reds",
+                                  reverse = FALSE,
+                                  middle = 0) {
     ggplot2::scale_colour_gradientn(
-        colours = cmap_pal_continuous(palette, reverse = reverse)(256)
+        colours = cmap_pal_continuous(palette, reverse = reverse)(256),
+        rescaler = mid_rescaler2(middle)
     )
 }
 

--- a/man/cmap_fill_continuous.Rd
+++ b/man/cmap_fill_continuous.Rd
@@ -4,7 +4,8 @@
 \alias{cmap_fill_continuous}
 \alias{cmap_color_continuous}
 \alias{cmap_colour_continuous}
-\title{Apply continuous CMAP palettes to ggplot2 aesthetics}
+\title{Apply continuous CMAP palettes to ggplot2 aesthetics. On diverging palettes,
+a midpoint can be manually adjusted (defaults to 0)}
 \usage{
 cmap_fill_continuous(palette = "seq_reds", reverse = FALSE, middle = 0)
 
@@ -13,15 +14,16 @@ cmap_color_continuous(palette = "seq_reds", reverse = FALSE, middle = 0)
 cmap_colour_continuous(palette = "seq_reds", reverse = FALSE, middle = 0)
 }
 \arguments{
-\item{palette}{Choose from 'cmap_gradients' list}
+\item{palette}{String; Choose from 'cmap_gradients' list}
 
-\item{reverse}{Logical; reverse color order?}
+\item{reverse}{Logical; Reverse color order?}
 
-\item{middle}{Numeric, sets midpoint for diverging color palettes. Default =
+\item{middle}{Numeric; Sets midpoint for diverging color palettes. Default =
 0.}
 }
 \description{
-Pick the function depending on the aesthetic of your ggplot object (fill or color)
+Pick the function depending on the aesthetic of your ggplot object (fill or
+color)
 }
 \section{Functions}{
 \itemize{

--- a/man/cmap_fill_continuous.Rd
+++ b/man/cmap_fill_continuous.Rd
@@ -6,16 +6,19 @@
 \alias{cmap_colour_continuous}
 \title{Apply continuous CMAP palettes to ggplot2 aesthetics}
 \usage{
-cmap_fill_continuous(palette = "seq_reds", reverse = FALSE)
+cmap_fill_continuous(palette = "seq_reds", reverse = FALSE, middle = 0)
 
-cmap_color_continuous(palette = "seq_reds", reverse = FALSE)
+cmap_color_continuous(palette = "seq_reds", reverse = FALSE, middle = 0)
 
-cmap_colour_continuous(palette = "seq_reds", reverse = FALSE)
+cmap_colour_continuous(palette = "seq_reds", reverse = FALSE, middle = 0)
 }
 \arguments{
 \item{palette}{Choose from 'cmap_gradients' list}
 
 \item{reverse}{Logical; reverse color order?}
+
+\item{middle}{Numeric, sets midpoint for diverging color palettes. Default =
+0.}
 }
 \description{
 Pick the function depending on the aesthetic of your ggplot object (fill or color)


### PR DESCRIPTION
Allows setting of midpoints on diverging palettes (defaults to 0). I've configured it so that it only applies to palettes that begin with `div`.