### PR TITLE
Tick marks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmapplot
 Title: CMAP Themes and Color Palettes
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
     person("Matthew", "Stern",
            role = c("aut", "cre"),

--- a/R/cmapplot.R
+++ b/R/cmapplot.R
@@ -101,7 +101,7 @@ cmapplot_globals <- list(
     lwd_strongline = 1,
     lwd_plotline = 3,
     lwd_topline = 2,
-    length_ticks = 10,
+    length_ticks = 7,
     margin_topline_t = 5,
     margin_title_t = 5,
     margin_title_b = 5,

--- a/R/cmapplot.R
+++ b/R/cmapplot.R
@@ -43,6 +43,7 @@
 #'    \item \code{lwd_topline}: The width of the line above the plot and title. \strong{(F)}
 #'    \item \code{margin_topline_t}: The margin between the top edge of the
 #'    image and the top line. \strong{(F)}
+#'    \item \code{length_ticks}: The length of the axis ticks (if shown).\strong{(T)}
 #'    \item \code{margin_title_t}: The margin between the top line and the
 #'    title. \strong{(F)}
 #'    \item \code{margin_title_b}: The margin between the title and the caption. \strong{(F)}
@@ -100,6 +101,7 @@ cmapplot_globals <- list(
     lwd_strongline = 1,
     lwd_plotline = 3,
     lwd_topline = 2,
+    length_ticks = 10,
     margin_topline_t = 5,
     margin_title_t = 5,
     margin_title_b = 5,

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -114,15 +114,11 @@ theme_cmap <- function(
   obj <- list()
   attr <- list()
 
-
   # create a helper function to more easily add items to the obj list
   add_to_obj <- function(newitem){
     obj <<- append(get("obj", parent.frame()), list(newitem))
     NULL
   }
-
-  # add base theme to object list
-  add_to_obj(theme_cmap_base(consts = consts, debug = debug))
 
   # introduce x label, if specified
   if(!is.null(xlab)){
@@ -150,62 +146,6 @@ theme_cmap <- function(
                                    color = cmapplot_globals$colors$blackish))
   }
 
-  # Introduce horizontal gridlines if specified
-  if (grepl("h", gridlines)) {
-    add_to_obj(ggplot2::theme(
-      panel.grid.major.y = ggplot2::element_line(
-        size = gg_lwd_convert(consts$lwd_gridline),
-        color = cmapplot_globals$colors$blackish)
-    ))
-  }
-
-  # Introduce vertical gridlines if specified
-  if (grepl("v", gridlines)) {
-    add_to_obj(ggplot2::theme(
-      panel.grid.major.x = ggplot2::element_line(
-        size = gg_lwd_convert(consts$lwd_gridline),
-        color = cmapplot_globals$colors$blackish)
-    ))
-  }
-
-  # Introduce x axis line if specified
-  if (grepl("x", axislines)) {
-    add_to_obj(ggplot2::theme(
-      axis.line.x = ggplot2::element_line(
-        size = gg_lwd_convert(consts$lwd_gridline),
-        color = cmapplot_globals$colors$blackish)
-    ))
-  }
-
-  # Introduce y axis line if specified
-  if (grepl("y", axislines)) {
-    add_to_obj(ggplot2::theme(
-      axis.line.y = ggplot2::element_line(
-        size = gg_lwd_convert(consts$lwd_gridline),
-        color = cmapplot_globals$colors$blackish)
-    ))
-  }
-
-  # Introduce x axis ticks if specified
-  if (grepl("x", axisticks)) {
-    add_to_obj(ggplot2::theme(
-      axis.ticks.x = ggplot2::element_line(
-        size = gg_lwd_convert(consts$lwd_gridline),
-        color = cmapplot_globals$colors$blackish),
-      axis.ticks.length.x = unit(consts$length_ticks,"bigpts")
-    ))
-  }
-
-  # Introduce y axis ticks if specified
-  if (grepl("y", axisticks)) {
-    add_to_obj(ggplot2::theme(
-      axis.ticks.y = ggplot2::element_line(
-        size = gg_lwd_convert(consts$lwd_gridline),
-        color = cmapplot_globals$colors$blackish),
-      axis.ticks.length.y = unit(consts$length_ticks,"bigpts")
-    ))
-  }
-
   # only edit legend columns if value is added
   if (!is.null(legend.max.columns)){
       # set maximum number of columns for legend based on either "fill" or "col" to reflect different geom structures
@@ -215,17 +155,70 @@ theme_cmap <- function(
                  )
   }
 
+  # add base theme to object list
+  add_to_obj(theme_cmap_base(consts = consts, debug = debug))
+
   # hide legend if specified
   if (!show.legend){
     attr[["legend.position"]] <- "none"
   }
 
-  # add any extra args to theme attributes
-  attr <- append(attr, list(...))
+  # Introduce horizontal gridlines if specified
+  if (grepl("h", gridlines)) {
+    attr[["panel.grid.major.y"]] <- ggplot2::element_line(
+      size = gg_lwd_convert(consts$lwd_gridline),
+      color = cmapplot_globals$colors$blackish)
+  }
 
-  # construct final list to return
-  append(obj, list(do.call(theme, attr)))
+  # Introduce vertical gridlines if specified
+  if (grepl("v", gridlines)) {
+    attr[["panel.grid.major.x"]] <- ggplot2::element_line(
+      size = gg_lwd_convert(consts$lwd_gridline),
+      color = cmapplot_globals$colors$blackish)
+  }
 
+  # Introduce x axis line if specified
+  if (grepl("x", axislines)) {
+    attr[["axis.line.x"]] <- ggplot2::element_line(
+      size = gg_lwd_convert(consts$lwd_gridline),
+      color = cmapplot_globals$colors$blackish)
+  }
+
+  # Introduce x axis line if specified
+  if (grepl("y", axislines)) {
+    attr[["axis.line.y"]] <- ggplot2::element_line(
+      size = gg_lwd_convert(consts$lwd_gridline),
+      color = cmapplot_globals$colors$blackish)
+  }
+
+  # Introduce x axis ticks if specified
+  if (grepl("x", axisticks)) {
+    attr[["axis.ticks.x"]] <- ggplot2::element_line(
+      size = gg_lwd_convert(consts$lwd_gridline),
+      color = cmapplot_globals$colors$blackish)
+    attr[["axis.ticks.length.x"]] <- unit(consts$length_ticks,"bigpts")
+  }
+
+  # Introduce y axis ticks if specified
+  if (grepl("y", axisticks)) {
+    attr[["axis.ticks.y"]] <- ggplot2::element_line(
+      size = gg_lwd_convert(consts$lwd_gridline),
+      color = cmapplot_globals$colors$blackish)
+    attr[["axis.ticks.length.y"]] <- unit(consts$length_ticks,"bigpts")
+  }
+
+  # add these theme elements to the list (if any new attributes added)
+  if(length(attr) > 0) {
+  add_to_obj(list(do.call(theme, attr)))
+  }
+
+  # add any extra args to theme attributes (if any additional arguments present)
+  if(length(list(...)) > 0) {
+  add_to_obj(list(do.call(theme, list(...))))
+  }
+
+  # return final list
+  return(obj)
 }
 
 

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -31,6 +31,12 @@
 #'@param axislines Char, the axis lines to be displayed on the chart. Acceptable
 #'  values are "x" (x axis only), "y" (y axis only), "xy" (both axes), and
 #'  "none" (neither, the default).
+#'@param axisticks Char, the axis ticks to be displayed on the chart. Acceptable
+#'  values are "x" (x axis only), "y" (y axis only), "xy" (both axes), and
+#'  "none" (neither, the default). Because \code{ggplot2} defaults to moderately
+#'  expanding the range of displayed data, this may need to be accompanied by a
+#'  call to \code{expand = c(0, 0)} within an appropriate \code{scale_*_*}
+#'  argument in order for ticks to appear to touch the outermost gridline(s).
 #'@param show.legend Bool, \code{TRUE} is the default. \code{FALSE} to hide the
 #'  legend.
 #'@param legend.max.columns Integer, the maximum number of columns in the
@@ -80,6 +86,7 @@ theme_cmap <- function(
   hline = NULL, vline = NULL,
   gridlines = c("h", "v", "hv", "none"),
   axislines = c("none", "x", "y", "xy"),
+  axisticks = c("none","x","y","xy"),
   show.legend = TRUE,
   legend.max.columns = NULL,
   debug = FALSE,
@@ -101,6 +108,7 @@ theme_cmap <- function(
   # Validate parameters, throw error if invalid
   gridlines <- match.arg(gridlines)
   axislines <- match.arg(axislines)
+  axisticks <- match.arg(axisticks)
 
   # create blank list of gg objects and theme attributes to return
   obj <- list()
@@ -175,6 +183,26 @@ theme_cmap <- function(
       axis.line.y = ggplot2::element_line(
         size = gg_lwd_convert(consts$lwd_gridline),
         color = cmapplot_globals$colors$blackish)
+    ))
+  }
+
+  # Introduce x axis ticks if specified
+  if (grepl("x", axisticks)) {
+    add_to_obj(ggplot2::theme(
+      axis.ticks.x = ggplot2::element_line(
+        size = gg_lwd_convert(consts$lwd_gridline),
+        color = cmapplot_globals$colors$blackish),
+      axis.ticks.length.x = unit(consts$length_ticks,"bigpts")
+    ))
+  }
+
+  # Introduce y axis ticks if specified
+  if (grepl("y", axisticks)) {
+    add_to_obj(ggplot2::theme(
+      axis.ticks.y = ggplot2::element_line(
+        size = gg_lwd_convert(consts$lwd_gridline),
+        color = cmapplot_globals$colors$blackish),
+      axis.ticks.length.y = unit(consts$length_ticks,"bigpts")
     ))
   }
 

--- a/R/theme_cmap.R
+++ b/R/theme_cmap.R
@@ -94,6 +94,8 @@ theme_cmap <- function(
   ...
 ) {
 
+  # Initialization --------------------------------------------------
+
   # Generate an explicit message to user if Whitney font family is not available
   if (!(cmapplot_globals$use_whitney)) {
     message("'Whitney' font family not found. Using a substitute...")
@@ -110,111 +112,135 @@ theme_cmap <- function(
   axislines <- match.arg(axislines)
   axisticks <- match.arg(axisticks)
 
-  # create blank list of gg objects and theme attributes to return
-  obj <- list()
-  attr <- list()
+  # Introduce elements based on args ---------------------------------
 
-  # create a helper function to more easily add items to the obj list
+  # create blank list of gg objects to be returned by this function
+  obj <- list()
+
+  # Create a helper function to more easily add items to the obj list
+  # This is just a shorthand for:
+  # obj <- append(obj, [item] )
   add_to_obj <- function(newitem){
     obj <<- append(get("obj", parent.frame()), list(newitem))
     NULL
   }
 
-  # introduce x label, if specified
+  # create a blank list of ggplot2theme elements to return in a
+  # theme call at the end of the function. Items in this list should
+  # be named with valid ggplot2::theme() argument names.
+  attr <- list()
+
+  # x label, if specified
   if(!is.null(xlab)){
-    attr[["axis.title.x"]] <- element_text(margin = margin(t = consts$half_line / 2), vjust = 1, inherit.blank = FALSE)
+    attr[["axis.title.x"]] <- ggplot2::element_text(
+      margin = ggplot2::margin(t = consts$half_line / 2),
+      vjust = 1,
+      inherit.blank = FALSE)
+
     add_to_obj(ggplot2::xlab(xlab))
   }
 
-  # introduce y label, if specified
+  # y label, if specified
   if(!is.null(ylab)){
-    attr[["axis.title.y"]] <- element_text(angle = 90, margin = margin(r = consts$half_line / 2), vjust = 1, inherit.blank = FALSE)
+    attr[["axis.title.y"]] <- ggplot2::element_text(
+      angle = 90,
+      margin = ggplot2::margin(r = consts$half_line / 2),
+      vjust = 1,
+      inherit.blank = FALSE)
+
     add_to_obj(ggplot2::ylab(ylab))
   }
 
-  # Add x origin line, if specified
+  # x origin line, if specified
   if(!is.null(hline)){
-    add_to_obj(ggplot2::geom_hline(yintercept = hline,
-                                   size = gg_lwd_convert(consts$lwd_strongline),
-                                   color = cmapplot_globals$colors$blackish))
+    add_to_obj(ggplot2::geom_hline(
+      yintercept = hline,
+      size = gg_lwd_convert(consts$lwd_strongline),
+      color = cmapplot_globals$colors$blackish))
   }
 
-  # Add y origin line, if specified
+  # y origin line, if specified
   if(!is.null(vline)){
-    add_to_obj(ggplot2::geom_vline(xintercept = vline,
-                                   size = gg_lwd_convert(consts$lwd_strongline),
-                                   color = cmapplot_globals$colors$blackish))
+    add_to_obj(ggplot2::geom_vline(
+      xintercept = vline,
+      size = gg_lwd_convert(consts$lwd_strongline),
+      color = cmapplot_globals$colors$blackish))
   }
 
-  # only edit legend columns if value is added
+  # set legend column max, if specified
   if (!is.null(legend.max.columns)){
-      # set maximum number of columns for legend based on either "fill" or "col" to reflect different geom structures
-      add_to_obj(ggplot2::guides(fill = guide_legend(ncol = legend.max.columns),
-                      col  = guide_legend(ncol = legend.max.columns)
-                      )
-                 )
+      # set for legend based on either "fill" or "col" to reflect different geom structures
+      add_to_obj(ggplot2::guides(
+        fill = guide_legend(ncol = legend.max.columns),
+        col  = guide_legend(ncol = legend.max.columns)))
   }
-
-  # add base theme to object list
-  add_to_obj(theme_cmap_base(consts = consts, debug = debug))
 
   # hide legend if specified
   if (!show.legend){
     attr[["legend.position"]] <- "none"
   }
 
-  # Introduce horizontal gridlines if specified
+  # horizontal gridlines, if specified
   if (grepl("h", gridlines)) {
     attr[["panel.grid.major.y"]] <- ggplot2::element_line(
       size = gg_lwd_convert(consts$lwd_gridline),
       color = cmapplot_globals$colors$blackish)
   }
 
-  # Introduce vertical gridlines if specified
+  # vertical gridlines, if specified
   if (grepl("v", gridlines)) {
     attr[["panel.grid.major.x"]] <- ggplot2::element_line(
       size = gg_lwd_convert(consts$lwd_gridline),
       color = cmapplot_globals$colors$blackish)
   }
 
-  # Introduce x axis line if specified
+  # x axis line, if specified
   if (grepl("x", axislines)) {
     attr[["axis.line.x"]] <- ggplot2::element_line(
       size = gg_lwd_convert(consts$lwd_gridline),
       color = cmapplot_globals$colors$blackish)
   }
 
-  # Introduce x axis line if specified
+  # y axis line, if specified
   if (grepl("y", axislines)) {
     attr[["axis.line.y"]] <- ggplot2::element_line(
       size = gg_lwd_convert(consts$lwd_gridline),
       color = cmapplot_globals$colors$blackish)
   }
 
-  # Introduce x axis ticks if specified
+  # x axis ticks, if specified
   if (grepl("x", axisticks)) {
     attr[["axis.ticks.x"]] <- ggplot2::element_line(
       size = gg_lwd_convert(consts$lwd_gridline),
       color = cmapplot_globals$colors$blackish)
+
     attr[["axis.ticks.length.x"]] <- unit(consts$length_ticks,"bigpts")
   }
 
-  # Introduce y axis ticks if specified
+  # y axis ticks, if specified
   if (grepl("y", axisticks)) {
     attr[["axis.ticks.y"]] <- ggplot2::element_line(
       size = gg_lwd_convert(consts$lwd_gridline),
       color = cmapplot_globals$colors$blackish)
+
     attr[["axis.ticks.length.y"]] <- unit(consts$length_ticks,"bigpts")
   }
 
-  # add these theme elements to the list (if any new attributes added)
+  # Construct theme elements -----------------------------------------
+
+  # add base theme to object list
+  add_to_obj(theme_cmap_base(consts = consts, debug = debug))
+
+  # add `attr` theme elements to the list in a new `ggplot2::theme()` object,
+  # so that they override `theme_cmap_base()` if needed
   if(length(attr) > 0) {
-  add_to_obj(list(do.call(theme, attr)))
+    add_to_obj(do.call(theme, attr))
   }
 
-  # add any extra args to theme attributes (if any additional arguments present)
+  # add extra theme arguments to a new `ggplot2::theme()` object,
+  # so that they override any previous theme arguments
   if(length(list(...)) > 0) {
-  add_to_obj(list(do.call(theme, list(...))))
+    add_to_obj(do.call(theme, list(...)))
   }
 
   # return final list

--- a/man/cmapplot_globals.Rd
+++ b/man/cmapplot_globals.Rd
@@ -36,6 +36,7 @@ and a list of constants which aid in drawing cmap-themed plots.
    \item \code{lwd_topline}: The width of the line above the plot and title. \strong{(F)}
    \item \code{margin_topline_t}: The margin between the top edge of the
    image and the top line. \strong{(F)}
+   \item \code{length_ticks}: The length of the axis ticks (if shown).\strong{(T)}
    \item \code{margin_title_t}: The margin between the top line and the
    title. \strong{(F)}
    \item \code{margin_title_b}: The margin between the title and the caption. \strong{(F)}

--- a/man/theme_cmap.Rd
+++ b/man/theme_cmap.Rd
@@ -11,6 +11,7 @@ theme_cmap(
   vline = NULL,
   gridlines = c("h", "v", "hv", "none"),
   axislines = c("none", "x", "y", "xy"),
+  axisticks = c("none", "x", "y", "xy"),
   show.legend = TRUE,
   legend.max.columns = NULL,
   debug = FALSE,
@@ -39,6 +40,13 @@ only), "hv" (both horizontal and vertical), and "none" (neither).}
 \item{axislines}{Char, the axis lines to be displayed on the chart. Acceptable
 values are "x" (x axis only), "y" (y axis only), "xy" (both axes), and
 "none" (neither, the default).}
+
+\item{axisticks}{Char, the axis ticks to be displayed on the chart. Acceptable
+values are "x" (x axis only), "y" (y axis only), "xy" (both axes), and
+"none" (neither, the default). Because \code{ggplot2} defaults to moderately
+expanding the range of displayed data, this may need to be accompanied by a
+call to \code{expand = c(0, 0)} within an appropriate \code{scale_*_*}
+argument in order for ticks to appear to touch the outermost gridline(s).}
 
 \item{show.legend}{Bool, \code{TRUE} is the default. \code{FALSE} to hide the
 legend.}

--- a/vignettes/plots.Rmd
+++ b/vignettes/plots.Rmd
@@ -79,6 +79,17 @@ p + theme_cmap(ylab = "Annual Ridership (Millions)",
   geom_line()
 ```
 
+
+`theme_cmap()` also allows users to easily add tick marks on the x- and/or the y-axes, using the argument `axisticks`. Note that here, some additional manipulation of the y-axis scale is necessary for the axis ticks to touch the lowest horizontal gridline (this is to override `ggplot2`'s default behavior, which expands the scale slightly beyond the extent of the data for aesthetic reasons).
+```{r mods2, message = FALSE}
+p + scale_y_continuous(breaks = c(0, 200, 400), 
+                       limits = c(-1, 575),
+                       expand = c(0, 0)) + 
+  theme_cmap(ylab = "Annual Ridership (Millions)",
+             axisticks = "x") +
+  geom_line()
+```
+
 ### Overriding plotting defaults
 
 The package contains a list of default values (`cmapplot_globals$consts`) that control various plotting constants. Most of these impact the function `finalize_plot()`, but a few impact `theme_cmap()`. For a complete description of these constants, see `?cmapplot_globals`. 
@@ -96,15 +107,11 @@ p + scale_x_continuous(labels = c("1980", "1990", "2000", "2010", "A very long l
 
 ### Further theme modifications
 
-In addition, any ggplot2 theme element can also be modified directly in `theme_cmap()` by passing valid arguments from the `ggplot2::theme()` function. In the following example, the addition of `axis.ticks.x` and the establishment of an `axis.ticks.length.x` "turns on" the tick marks automatically turned off by `theme_cmap()`'s underlying theme. Note that here, some additional manipulation of the y-axis scale is necessary for the axis ticks to touch the lowest horizontal gridline.
+In addition, any ggplot2 theme element can also be modified directly in `theme_cmap()` by passing valid arguments from the `ggplot2::theme()` function. In the following example, the addition of `panel.grid.major.y = element_line(color = "light gray")` modifies the default color of a horizontal grid line, changing it from black to light gray.
 
-```{r mods2, message = FALSE}
-p + scale_y_continuous(breaks = c(0, 200, 400), 
-                       limits = c(-1, 575),
-                       expand = c(0, 0)) + 
-  theme_cmap(ylab = "Annual Ridership (Millions)",
-             axis.ticks.x = element_line(color = "red"),
-             axis.ticks.length.x = unit(10, "bigpts")) +
+```{r mods3, message = FALSE}
+p + theme_cmap(ylab = "Annual Ridership (Millions)",
+               panel.grid.major.y = element_line(color = "light gray")) +
   geom_line()
 ```
 


### PR DESCRIPTION
This PR adds an argument to `theme_cmap()` that allows for the easier addition of tick marks on both the x and y axes. It includes a note in the documentation about the edits required for them to touch axes (involving a manual edit of `expand` inside the appropriate `scale` call). I didn't think it made sense to have that adjustment to `expand` automatically happen, since it is unrelated to tick marks and there are situations where you might not want it, but open to other thoughts there (and if so, ideas on how to implement it).

If approved, we'll want to modify the pkgdown section on this accordingly.