### PR TITLE
Creation of a vignette for installation on CMAP computers

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -50,6 +50,8 @@ devtools::install_github("CMAP-REPOS/cmapplot", build_vignettes=TRUE)
 library(cmapplot)
 ```
 
+For more detailed information about installing the package, particularly on a CMAP-issued computer, see [this article](https://cmap-repos.github.io/cmapplot/articles/installation.html).
+
 To install on macOS, users must install [XQuartz](https://www.xquartz.org) before cmapplot can be loaded. (This can be easily accomplished via the [Homebrew](https://brew.sh) package manager with the command `brew cask install xquartz`.)
 
 **A note about fonts**: The cmapplot package works best when installed on a computer with the Whitney family of fonts installed (specifically the Book, Medium, and Semibold variants). If installed on a computer *without* Whitney, the package will still work, but the fonts will default to Calibri (on Windows) or Arial (on macOS/Linux).
@@ -88,10 +90,7 @@ finalize_plot(title = "Regional population and labor force participation",
 
 While this package is designed to make the application of CMAP design standards to plots relatively easy, developing a professional, finished plot in R will require a decent familiarity with the grammar of [ggplot2](ggplot2.tidyverse.org/). Excellent resources in this category already exist:
 
-- The [R graphics cookbook](https://r-graphics.org/) provides accessible examples of how to make almost [any type](https://r-graphics.org/recipe-miscgraph-vectorfield) of plot, as well as how to modify things like [limits, scales](https://r-graphics.org/recipe-axes-range), [coordinate systems](https://r-graphics.org/recipe-axes-polar), and [facets](https://r-graphics.org/recipe-facet-basic).
-
-- The [ggplot2 book](https://ggplot2-book.org/) delves deeper into why and how ggplot2 works the way it does, also with distinct chapters on topics like [scales](https://ggplot2-book.org/scales-guides.html), [coordinate systems](https://ggplot2-book.org/coord.html), [facets](https://ggplot2-book.org/facet.html), etc.
-
-- The [ggplot2](ggplot2.tidyverse.org/) website.
-
-- The [R for Data Science (R4DS)](https://r4ds.had.co.nz/) book, especially the [Graphics for Communication](https://r4ds.had.co.nz/graphics-for-communication.html) chapter.
+  - The [R graphics cookbook](https://r-graphics.org/) provides accessible examples of how to make almost [any type](https://r-graphics.org/recipe-miscgraph-vectorfield) of plot, as well as how to modify things like [limits, scales](https://r-graphics.org/recipe-axes-range), [coordinate systems](https://r-graphics.org/recipe-axes-polar), and [facets](https://r-graphics.org/recipe-facet-basic).
+  - The [ggplot2 book](https://ggplot2-book.org/) delves deeper into why and how ggplot2 works the way it does, also with distinct chapters on topics like [scales](https://ggplot2-book.org/scales-guides.html), [coordinate systems](https://ggplot2-book.org/coord.html), [facets](https://ggplot2-book.org/facet.html), etc.
+  - The [ggplot2](ggplot2.tidyverse.org/) website.
+  - The [R for Data Science (R4DS)](https://r4ds.had.co.nz/) book, especially the [Graphics for Communication](https://r4ds.had.co.nz/graphics-for-communication.html) chapter.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ devtools::install_github("CMAP-REPOS/cmapplot", build_vignettes=TRUE)
 library(cmapplot)
 ```
 
+For more detailed information about installing the package, particularly
+on a CMAP-issued computer, see [this
+article](https://cmap-repos.github.io/cmapplot/articles/installation.html).
+
 To install on macOS, users must install
 [XQuartz](https://www.xquartz.org) before cmapplot can be loaded. (This
 can be easily accomplished via the [Homebrew](https://brew.sh) package
@@ -99,24 +103,21 @@ plot in R will require a decent familiarity with the grammar of
 [ggplot2](ggplot2.tidyverse.org/). Excellent resources in this category
 already exist:
 
--   The [R graphics cookbook](https://r-graphics.org/) provides
+  - The [R graphics cookbook](https://r-graphics.org/) provides
     accessible examples of how to make almost [any
     type](https://r-graphics.org/recipe-miscgraph-vectorfield) of plot,
     as well as how to modify things like [limits,
     scales](https://r-graphics.org/recipe-axes-range), [coordinate
     systems](https://r-graphics.org/recipe-axes-polar), and
     [facets](https://r-graphics.org/recipe-facet-basic).
-
--   The [ggplot2 book](https://ggplot2-book.org/) delves deeper into why
+  - The [ggplot2 book](https://ggplot2-book.org/) delves deeper into why
     and how ggplot2 works the way it does, also with distinct chapters
     on topics like
     [scales](https://ggplot2-book.org/scales-guides.html), [coordinate
     systems](https://ggplot2-book.org/coord.html),
     [facets](https://ggplot2-book.org/facet.html), etc.
-
--   The [ggplot2](ggplot2.tidyverse.org/) website.
-
--   The [R for Data Science (R4DS)](https://r4ds.had.co.nz/) book,
+  - The [ggplot2](ggplot2.tidyverse.org/) website.
+  - The [R for Data Science (R4DS)](https://r4ds.had.co.nz/) book,
     especially the [Graphics for
     Communication](https://r4ds.had.co.nz/graphics-for-communication.html)
     chapter.

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -52,3 +52,4 @@ articles:
   - finalize
   - colors
   - cookbook
+  - installation

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -48,8 +48,8 @@ articles:
 - title: Articles
   navbar: ~
   contents:
+  - installation
   - plots
   - finalize
   - colors
   - cookbook
-  - installation

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -7,27 +7,28 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-This vignette gives an overview of how to install cmapplot onto a CMAP-issued computer.
+This vignette provides an overview of how to install cmapplot, with a specific focus on CMAP-issued computers. This guide presumes that the user does *not* have administrator privileges.
 
 
-## Installing necessary components
+## Prerequisites
 
-Your CMAP computer should already have a copy of both R and RStudio installed. If it does not, please contact IT, as they will be able to assist you in installing both (while you should be able to install RStudio on your own, installing R typically requires administrator privileges).
+Your CMAP computer should already have both R and RStudio installed. If it does not, please submit an IT helpdesk request to install them. (While you can install RStudio on your own by [downloading](https://rstudio.com/products/rstudio/download/#download) the .zip -- *not* .exe -- version, installing R itself requires administrator privileges).
 
-Once you have confirmed that you have a working version of RStudio and R on your computer, you will need to download and install several packages and utilities. One of these can be installed directly through RStudio: `devtools`. You can install it by running the following code:
+Once you have working versions of R and RStudio on your computer, you will also need to download an additional utility called Rtools. You can download the installation file for Rtools [here](https://cran.rstudio.com/bin/windows/Rtools/). Because of IT restrictions, you will need to choose an installation folder that you have write access to. The Rtools installer defaults to **C:\rtools40**, which is fine. However, if you do not want to install it there, you may create another folder in your own user sub-directory (e.g. **C:\Users\your_username\rtools**).
 
-``` r
-## Install devtools 
-install.packages("devtools")
+Finally, before you can install cmapplot, you will need to download and install several packages and utilities. In particular, the "devtools" and "tidyverse" packages *must* be installed before cmapplot can be installed. You can install it by running the following code in RStudio:
+
+```{r install-devtools, eval=FALSE}
+## Install devtools and tidyverse
+install.packages(c("devtools", "tidyverse"))
 ```
 
-To build the cmapplot package, you will also need to download a utility called Rtools. You can download the installation file for Rtools [here](https://cran.rstudio.com/bin/windows/Rtools/). Because of administrator restrictions, you will need to choose an installation folder that you have write access to. The installation wizard should default to the top-level "C:" folder, which should work for installation. However, if you do not want to install it there, you may create another folder in your own User sub-directory (note that while "Program Files" is an apparently natural home, installing it there requires administrator privileges).
 
 ## Installing and loading cmapplot
 
-Once you have successfully downloaded and installed Rtools, you are ready to install cmapplot. Run the following to install or update cmapplot:
+Once you have successfully downloaded and installed Rtools and the "devtools" and "tidyverse" packages, you are ready to install cmapplot. Run the following to install or update cmapplot:
 
-``` r
+```{r install-cmapplot, eval=FALSE}
 ## Install current version from GitHub
 devtools::install_github("CMAP-REPOS/cmapplot", build_vignettes=TRUE)
 
@@ -37,6 +38,9 @@ library(cmapplot)
 
 After completing these steps, your computer should be ready to use and export graphics using cmapplot. 
 
-## Fonts
 
-Because your laptop should already have Whitney installed, your graphics should be outputted using the Whitney font families. If, however, you receive an error message warning you that Whitney is not installed, please verify that Whitney is installed on your device. If it is not, please contact IT to ask for their help in getting the font added to your machine. If Whitney is installed, but you are still receiving the warning message, please reach out to a member of the cmapplot development team.
+## CMAP fonts
+
+CMAP's design standards require the usage of the Whitney typeface. Whitney is not freely available, but rather requires a license. On CMAP computers, which should already have the Whitney font family installed, cmapplot will use Whitney without any issues. If you receive a warning that Whitney is not installed when you load the package, please verify that the Whitney fonts (specifically the Book, Medium and Semibold variants) are installed in **C:\Windows\Fonts**. If it is not, please submit an IT helpdesk request to get it installed. If Whitney *is* already installed and you are receiving the warning message, please reach out to a member of the cmapplot development team.
+
+Non-CMAP users will have to license Whitney on their own, or else use cmapplot with its fall-back fonts: Calibri (on Windows) or Arial (on macOS/Linux).

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -26,7 +26,7 @@ install.packages(c("devtools", "tidyverse"))
 
 ## Installing and loading cmapplot
 
-Once you have successfully downloaded and installed Rtools and the "devtools" and "tidyverse" packages, you are ready to install cmapplot. Run the following code to install cmapplot:
+Once you have successfully downloaded and installed Rtools and the "devtools" and "tidyverse" packages, you are ready to install cmapplot. Run the following code to install and load cmapplot:
 
 ```{r install-cmapplot, eval=FALSE}
 ## Install/update cmapplot from GitHub

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -14,25 +14,25 @@ This vignette provides an overview of how to install cmapplot, with a specific f
 
 Your CMAP computer should already have both R and RStudio installed. If it does not, please submit an IT helpdesk request to install them. (While you can install RStudio on your own by [downloading](https://rstudio.com/products/rstudio/download/#download) the .zip -- *not* .exe -- version, installing R itself requires administrator privileges).
 
-Once you have working versions of R and RStudio on your computer, you will also need to download an additional utility called Rtools. You can download the installation file for Rtools [here](https://cran.rstudio.com/bin/windows/Rtools/). Because of IT restrictions, you will need to choose an installation folder that you have write access to. The Rtools installer defaults to **C:\rtools40**, which is fine. However, if you do not want to install it there, you may create another folder in your own user sub-directory (e.g. **C:\Users\your_username\rtools**).
+Once you have working versions of R and RStudio on your computer, you will also need to download an additional utility called Rtools. You can download the installation file for Rtools [here](https://cran.rstudio.com/bin/windows/Rtools/). Because of IT restrictions, you will need to choose an installation folder that you have write access to. The Rtools installer defaults to **C:\\rtools40**, which is fine. However, if you do not want to install it there, you may create another folder in your own user sub-directory (e.g. **C:\\Users\\your_username\\rtools**).
 
-Finally, before you can install cmapplot, you will need to download and install several packages and utilities. In particular, the "devtools" and "tidyverse" packages *must* be installed before cmapplot can be installed. You can install it by running the following code in RStudio:
+Finally, before you can install cmapplot, you will need to download and install the "devtools" and "tidyverse" packages. You can install them by running the following code in RStudio:
 
 ```{r install-devtools, eval=FALSE}
-## Install devtools and tidyverse
+## Install devtools & tidyverse
 install.packages(c("devtools", "tidyverse"))
 ```
 
 
 ## Installing and loading cmapplot
 
-Once you have successfully downloaded and installed Rtools and the "devtools" and "tidyverse" packages, you are ready to install cmapplot. Run the following to install or update cmapplot:
+Once you have successfully downloaded and installed Rtools and the "devtools" and "tidyverse" packages, you are ready to install cmapplot. Run the following code to install cmapplot:
 
 ```{r install-cmapplot, eval=FALSE}
-## Install current version from GitHub
+## Install/update cmapplot from GitHub
 devtools::install_github("CMAP-REPOS/cmapplot", build_vignettes=TRUE)
 
-## Then load the package as you would any other
+## Load cmapplot
 library(cmapplot)
 ```
 
@@ -41,6 +41,6 @@ After completing these steps, your computer should be ready to use and export gr
 
 ## CMAP fonts
 
-CMAP's design standards require the usage of the Whitney typeface. Whitney is not freely available, but rather requires a license. On CMAP computers, which should already have the Whitney font family installed, cmapplot will use Whitney without any issues. If you receive a warning that Whitney is not installed when you load the package, please verify that the Whitney fonts (specifically the Book, Medium and Semibold variants) are installed in **C:\Windows\Fonts**. If it is not, please submit an IT helpdesk request to get it installed. If Whitney *is* already installed and you are receiving the warning message, please reach out to a member of the cmapplot development team.
+CMAP's design standards require the usage of the Whitney typeface. Whitney is not freely available, but rather requires a license. On CMAP computers, which should already have the Whitney font family installed, cmapplot will use Whitney without any issues. If you receive a warning that Whitney is not installed when you load the package, please verify that the Whitney fonts (specifically, the Book, Medium and Semibold variants) are installed in **C:\\Windows\\Fonts**. If it is not, please submit an IT helpdesk request to get it installed. If Whitney *is* already installed and you are receiving the warning message, please reach out to a member of the cmapplot development team.
 
 Non-CMAP users will have to license Whitney on their own, or else use cmapplot with its fall-back fonts: Calibri (on Windows) or Arial (on macOS/Linux).

--- a/vignettes/installation.Rmd
+++ b/vignettes/installation.Rmd
@@ -1,0 +1,42 @@
+---
+title: "Installing cmapplot on a CMAP computer"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Installing cmapplot on a CMAP computer}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+This vignette gives an overview of how to install cmapplot onto a CMAP-issued computer.
+
+
+## Installing necessary components
+
+Your CMAP computer should already have a copy of both R and RStudio installed. If it does not, please contact IT, as they will be able to assist you in installing both (while you should be able to install RStudio on your own, installing R typically requires administrator privileges).
+
+Once you have confirmed that you have a working version of RStudio and R on your computer, you will need to download and install several packages and utilities. One of these can be installed directly through RStudio: `devtools`. You can install it by running the following code:
+
+``` r
+## Install devtools 
+install.packages("devtools")
+```
+
+To build the cmapplot package, you will also need to download a utility called Rtools. You can download the installation file for Rtools [here](https://cran.rstudio.com/bin/windows/Rtools/). Because of administrator restrictions, you will need to choose an installation folder that you have write access to. The installation wizard should default to the top-level "C:" folder, which should work for installation. However, if you do not want to install it there, you may create another folder in your own User sub-directory (note that while "Program Files" is an apparently natural home, installing it there requires administrator privileges).
+
+## Installing and loading cmapplot
+
+Once you have successfully downloaded and installed Rtools, you are ready to install cmapplot. Run the following to install or update cmapplot:
+
+``` r
+## Install current version from GitHub
+devtools::install_github("CMAP-REPOS/cmapplot", build_vignettes=TRUE)
+
+## Then load the package as you would any other
+library(cmapplot)
+```
+
+After completing these steps, your computer should be ready to use and export graphics using cmapplot. 
+
+## Fonts
+
+Because your laptop should already have Whitney installed, your graphics should be outputted using the Whitney font families. If, however, you receive an error message warning you that Whitney is not installed, please verify that Whitney is installed on your device. If it is not, please contact IT to ask for their help in getting the font added to your machine. If Whitney is installed, but you are still receiving the warning message, please reach out to a member of the cmapplot development team.


### PR DESCRIPTION
A new vignette that outlines the steps needed to install cmapplot on a CMAP-issued computer - it isn't terribly complex, but it does require a few installation steps (specifically, getting Rtools).