### PR TITLE
Add ability to pass through scale arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmapplot
 Title: CMAP Themes and Color Palettes
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: c(
     person("Matthew", "Stern",
            role = c("aut", "cre"),

--- a/R/colors_continuous.R
+++ b/R/colors_continuous.R
@@ -128,6 +128,7 @@ mid_rescaler2 <- function(mid) {
 #' @param reverse Logical; Reverse color order?
 #' @param middle Numeric; Sets midpoint for diverging color palettes. Default =
 #'   0.
+#' @param ... Additional parameters passed on to the scale type
 #'
 #' @examples
 #' ggplot(dplyr::filter(grp_over_time, cluster=="Biopharmaceuticals"),
@@ -135,43 +136,49 @@ mid_rescaler2 <- function(mid) {
 #'     geom_line() +
 #'     cmap_color_continuous(palette = "seq_red_purple")
 #'
-#' @describeIn cmap_fill_continuous For fill aesthetic
+#' @describeIn cmap_fill_continuous for fill aesthetic
 #'
 #' @export
 cmap_fill_continuous <- function(palette = "seq_reds",
                                  reverse = FALSE,
-                                 middle = 0) {
+                                 middle = 0,
+                                 ...) {
     if (substr(palette,1,3) == "div") {
         ggplot2::scale_fill_gradientn(
             colours = cmap_pal_continuous(palette, reverse = reverse)(256),
-            rescaler = mid_rescaler2(middle)
+            rescaler = mid_rescaler2(middle),
+            ...
         )
     } else {
         ggplot2::scale_fill_gradientn(
-            colours = cmap_pal_continuous(palette, reverse = reverse)(256)
+            colours = cmap_pal_continuous(palette, reverse = reverse)(256),
+            ...
         )
     }
 }
 
 
-#' @describeIn cmap_fill_continuous For color aesthetic
+#' @describeIn cmap_fill_continuous for color aesthetic
 #'
 #' @export
 cmap_color_continuous <- function(palette = "seq_reds",
                                   reverse = FALSE,
-                                  middle = 0) {
+                                  middle = 0,
+                                  ...) {
     if (substr(palette,1,3) == "div") {
         ggplot2::scale_colour_gradientn(
             colours = cmap_pal_continuous(palette, reverse = reverse)(256),
-            rescaler = mid_rescaler2(middle)
+            rescaler = mid_rescaler2(middle),
+            ...
         )
     } else {
         ggplot2::scale_colour_gradientn(
-            colours = cmap_pal_continuous(palette, reverse = reverse)(256)
+            colours = cmap_pal_continuous(palette, reverse = reverse)(256),
+            ...
         )
     }
 }
 
-#' @describeIn cmap_fill_continuous For color aesthetic
+#' @describeIn cmap_fill_continuous for color aesthetic
 #' @export
 cmap_colour_continuous <- cmap_color_continuous

--- a/R/colors_discrete.R
+++ b/R/colors_discrete.R
@@ -3,7 +3,7 @@
 #' A selection of discrete color palettes from the CMAP color palette.
 #'
 #' @examples
-#' # Get names of avialable discrete palettes.
+#' # Get names of available discrete palettes.
 #' # (Call viz_palette("name_of_palette") to preview one.)
 #' names(cmap_palettes)
 #'
@@ -63,6 +63,7 @@ viz_palette <- function(pal, ttl = deparse(substitute(pal)), num = length(pal)) 
 #'
 #' @param palette Choose from 'cmap_palettes' list
 #' @param reverse Logical; reverse color order?
+#' @param ... Additional parameters passed on to the scale type
 #'
 #' @noRd
 cmap_pal_discrete <- function(palette = "prosperity", reverse = FALSE) {
@@ -81,6 +82,7 @@ cmap_pal_discrete <- function(palette = "prosperity", reverse = FALSE) {
 #'
 #' @param palette Choose from 'cmap_palettes' list
 #' @param reverse Logical; reverse color order?
+#' @param ... Additional parameters passed on to the scale type
 #'
 #' @examples
 #' ggplot(pop_and_laborforce_by_age, aes(x = variable, y = value, fill = age)) +
@@ -94,17 +96,21 @@ cmap_pal_discrete <- function(palette = "prosperity", reverse = FALSE) {
 #'
 #' @describeIn cmap_fill_discrete For fill aesthetic
 #' @export
-cmap_fill_discrete <- function(palette = "prosperity", reverse = FALSE) {
+cmap_fill_discrete <- function(palette = "prosperity", reverse = FALSE, ...) {
     ggplot2::discrete_scale(
-        "fill", "cmap_palettes", palette = cmap_pal_discrete(palette, reverse = reverse)
+        "fill", "cmap_palettes",
+        palette = cmap_pal_discrete(palette, reverse = reverse),
+        ...
     )
 }
 
 #' @describeIn cmap_fill_discrete For color aesthetic
 #' @export
-cmap_color_discrete <- function(palette = "prosperity", reverse = FALSE) {
+cmap_color_discrete <- function(palette = "prosperity", reverse = FALSE, ...) {
     ggplot2::discrete_scale(
-        "colour", "cmap_palettes", palette = cmap_pal_discrete(palette, reverse = reverse)
+        "colour", "cmap_palettes",
+        palette = cmap_pal_discrete(palette, reverse = reverse),
+        ...
     )
 }
 

--- a/man/cmap_fill_continuous.Rd
+++ b/man/cmap_fill_continuous.Rd
@@ -6,11 +6,11 @@
 \alias{cmap_colour_continuous}
 \title{Apply continuous CMAP palettes (gradients) to ggplot2 aesthetics}
 \usage{
-cmap_fill_continuous(palette = "seq_reds", reverse = FALSE, middle = 0)
+cmap_fill_continuous(palette = "seq_reds", reverse = FALSE, middle = 0, ...)
 
-cmap_color_continuous(palette = "seq_reds", reverse = FALSE, middle = 0)
+cmap_color_continuous(palette = "seq_reds", reverse = FALSE, middle = 0, ...)
 
-cmap_colour_continuous(palette = "seq_reds", reverse = FALSE, middle = 0)
+cmap_colour_continuous(palette = "seq_reds", reverse = FALSE, middle = 0, ...)
 }
 \arguments{
 \item{palette}{String; Choose from 'cmap_gradients' list}
@@ -19,6 +19,8 @@ cmap_colour_continuous(palette = "seq_reds", reverse = FALSE, middle = 0)
 
 \item{middle}{Numeric; Sets midpoint for diverging color palettes. Default =
 0.}
+
+\item{...}{Additional parameters passed on to the scale type}
 }
 \description{
 Pick the function depending on the aesthetic of your ggplot object (fill or
@@ -27,11 +29,11 @@ to 0). See \code{\link{cmap_gradients}} for a listing of available gradients.
 }
 \section{Functions}{
 \itemize{
-\item \code{cmap_fill_continuous}: For fill aesthetic
+\item \code{cmap_fill_continuous}: for fill aesthetic
 
-\item \code{cmap_color_continuous}: For color aesthetic
+\item \code{cmap_color_continuous}: for color aesthetic
 
-\item \code{cmap_colour_continuous}: For color aesthetic
+\item \code{cmap_colour_continuous}: for color aesthetic
 }}
 
 \examples{

--- a/man/cmap_fill_discrete.Rd
+++ b/man/cmap_fill_discrete.Rd
@@ -6,16 +6,18 @@
 \alias{cmap_colour_discrete}
 \title{Apply discrete CMAP palettes to ggplot2 aesthetics}
 \usage{
-cmap_fill_discrete(palette = "prosperity", reverse = FALSE)
+cmap_fill_discrete(palette = "prosperity", reverse = FALSE, ...)
 
-cmap_color_discrete(palette = "prosperity", reverse = FALSE)
+cmap_color_discrete(palette = "prosperity", reverse = FALSE, ...)
 
-cmap_colour_discrete(palette = "prosperity", reverse = FALSE)
+cmap_colour_discrete(palette = "prosperity", reverse = FALSE, ...)
 }
 \arguments{
 \item{palette}{Choose from 'cmap_palettes' list}
 
 \item{reverse}{Logical; reverse color order?}
+
+\item{...}{Additional parameters passed on to the scale type}
 }
 \description{
 Pick the function depending on the aesthetic of your ggplot object (fill or

--- a/man/cmap_palettes.Rd
+++ b/man/cmap_palettes.Rd
@@ -31,7 +31,7 @@ package}
 }}
 
 \examples{
-# Get names of avialable discrete palettes.
+# Get names of available discrete palettes.
 # (Call viz_palette("name_of_palette") to preview one.)
 names(cmap_palettes)
 


### PR DESCRIPTION
This PR tweaks the code for `cmap_fill_continuous`, `cmap_color_continuous`, and their discrete counterparts to allow for additional arguments to be passed through to the scales - e.g., this allows you to modify the text formatting of labels next to a continuous spectrum.

Not a huge update - we have this functionality in other functions in the package. I also incremented to 1.0.2.