### PR TITLE
add geom_label to default aes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmapplot
 Title: CMAP Themes and Color Palettes
-Version: 1.0.3
+Version: 1.0.4
 Authors@R: c(
     person("Matthew", "Stern",
            role = c("aut", "cre"),

--- a/R/cmapplot.R
+++ b/R/cmapplot.R
@@ -119,6 +119,7 @@ cmapplot_globals <- list(
 
   # list of geoms whose aesthetics will be customized
   geoms_that_change = c(
+    "Label",
     "Line",
     "Text",
     "TextLast",

--- a/R/default_aes.R
+++ b/R/default_aes.R
@@ -8,6 +8,12 @@
 #' @noRd
 init_cmap_default_aes <- function () {
   defaults <- list(
+    Label = list(
+      family = cmapplot_globals$font$strong$family,
+      fontface = ifelse(cmapplot_globals$font$strong$face == "bold", 2, 1),
+      size = cmapplot_globals$fsize$M/ggplot2::.pt, # pt-to-mm conversion
+      colour = cmapplot_globals$colors$blackish
+    ),
     Line = list(
       size = gg_lwd_convert(cmapplot_globals$consts$lwd_plotline)
     ),
@@ -54,7 +60,7 @@ init_cmap_default_aes <- function () {
 #' possible. The geoms impacted are stored in
 #' \code{cmapplot_globals$geoms_to_change}.
 #'
-#' These functions are employed implictly within \code{\link{finalize_plot}} to
+#' These functions are employed implicitly within \code{\link{finalize_plot}} to
 #' apply preferred aesthetic defaults to final outputs. They are only necessary
 #' to use explicitly if you would like plots to use these defaults
 #' pre-\code{finalize}.

--- a/man/cmap_default_aes.Rd
+++ b/man/cmap_default_aes.Rd
@@ -22,7 +22,7 @@ possible. The geoms impacted are stored in
 \code{cmapplot_globals$geoms_to_change}.
 }
 \details{
-These functions are employed implictly within \code{\link{finalize_plot}} to
+These functions are employed implicitly within \code{\link{finalize_plot}} to
 apply preferred aesthetic defaults to final outputs. They are only necessary
 to use explicitly if you would like plots to use these defaults
 pre-\code{finalize}.

--- a/vignettes/cookbook.Rmd
+++ b/vignettes/cookbook.Rmd
@@ -244,6 +244,9 @@ finalize_plot(
 
 The cmapplot package includes functionality for highlighting specified data using a distinct color. This is useful to compare Chicago against peer regions, for example.
 
+This plot also utilizes `geom_label`, an alternative to `geom_text` that draws a 
+rectangle behind each label to help it stand out from gridlines where they overlap. 
+
 #### Example code
 
 ```{r highlightbar, message=FALSE}
@@ -258,23 +261,25 @@ df <- tibble(
 p <- ggplot(data = df,
             mapping = aes(
               x = reorder(REGION, -MED_HH_INC), # Order race by decreasing income
-              y = MED_HH_INC,
-              fill = REGION  # Fill must be set for a highlighted chart
+              y = MED_HH_INC
             )) +
 
   # Add bars
-  geom_col(width = 0.5) +
+  geom_col(mapping = aes(fill = REGION),  # Fill must be set for a highlighted chart
+           width = 0.5) +
 
   # Add horizontal line at specified value
   geom_hline(yintercept = 55322) +
 
-  # Label bars
-  geom_text(
+  # Label bars. `geom_label` draws a rectangle behind the label, to prevent 
+  # overlap with gridlines
+  geom_label(
     mapping = aes(
-      y = MED_HH_INC + 2500,  # Offset by trial & error
+      y = MED_HH_INC + 2600,  # Offset by trial & error
       label = scales::label_dollar()(MED_HH_INC)  # Format labels as dollars
     ),
-    hjust = .5  # Center label (0 = left aligned, 1 = right aligned)
+    hjust = .5,  # Center label (0 = left aligned, 1 = right aligned)
+    label.size = 0 # necessary to not draw a line around the label box
   ) +
 
   # Annotate the horizontal line


### PR DESCRIPTION
This PR adds `geom_label` to the list of geoms that cmapplot overwrites default aesthetics for. Note that I can't get default_aes to modify the special arguments `label.padding`, `label.r`, and `label.size` -- it appears that these are not aesthetics, technically, but arguments of the geom_label function directly. So, we could modify these with custom functions like `geom_label_cmap()` if we wanted, but this seems unnecessary to me. 

This advances version to 1.0.4.