### PR TITLE
create news.md

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmapplot
 Title: CMAP Themes and Color Palettes
-Version: 1.1.1
+Version: 1.1.0
 Authors@R: c(
     person("Matthew", "Stern",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmapplot
 Title: CMAP Themes and Color Palettes
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: c(
     person("Matthew", "Stern",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,6 @@ Under-the-hood changes to `finalize_plot()` are documented in PR #111, specifica
 
 ### Backward compatibility notes
 Users who have written code with previous versions of cmapplot should note these known compatibility issues:
-
 * In `finalize_plot()`, the argument `caption_valign` has been deprecated and will now issue a message alert (but will still work, for now). Please update your code to ues the new argument `caption_align`. 
 
 
@@ -24,7 +23,7 @@ PR #110 | February 3, 2020
 # cmapplot 1.0.3
 PR #107 | February 2, 2020
 
-* modified `finalize_plot()` to accept `title_width = 0` without causing a fuss. This is a short-term fix, with more improvements coming.
+* Modified `finalize_plot()` to accept `title_width = 0` without causing a fuss. This is a short-term fix, with more improvements coming.
 * In `cmapplot_globals$consts`, eliminated `margin_title_r`, which created space between the title/caption and plotbox inside the title column. Replaced it  with `margin_plot_l`, which creates the same buffer but does so in the plot column, not the title column. This was necessary to keep an active left-hand margin in situations where `title_width = 0`.
 
 ### Backward compatibility notes
@@ -46,9 +45,8 @@ PR #100 | December 9, 2020
 * Improvement of tickmark handling via addition of `axisticks`  argument in `theme_cmap()` and new `length_ticks` default value in `cmapplot_globals$consts`
 * Substantial backend simplification of how `theme_cmap()` generates theme objects (not of substantial significance to users)
 
+
 # cmapplot 1.0.0
 December 1, 2020
 
 * initial package release 
-
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,45 @@
+# cmapplot 1.1.1
+February 22, 2020
+
+* Creates `NEWS.md` file and adds to pkgdown website.  
+
+# cmapplot 1.1.0
+February 22, 2020
+
+## Changelog
+This update primarily makes many changes to `finalize_plot()` to enable printing plots without the left-hand "title column" -- the area that contains the title and the caption. Most but not all changes are under the hood and should not impact the user. Those that will impact the user include:
+
+* setting `title_width = 0` now has the effect of eliminating the title and shifting the caption from the title column to directly below the plot
+* There is a new argument, `caption_align`, which takes numeric range 0 to 1. `0`, the default, aligns the caption bottom or left (in title-column and below-plot captions, respectively). `1` aligns the caption top or right. `0.5` centers. The argument `caption_valign` has been deprecated.
+
+Under-the-hood changes are documented in PR #111, specifically [here](https://github.com/CMAP-REPOS/cmapplot/pull/111#issuecomment-782779446). 
+
+## Backward compatibility notes
+Users who have written code with previous versions of cmapplot should note these known compatibility issues:
+
+* In `finalize_plot()`, the argument `caption_valign` has been deprecated and will now issue a message alert (but will still work, for now). Please update your code to ues the new argument `caption_align`. 
+
+
+# cmapplot 1.0.3
+February 2, 2020
+
+## Changelog
+* Improvement of tickmark handling via addition of `axisticks`  argument in `theme_cmap()` (#100)
+* Substantial backend simplification of how `theme_cmap()` generates theme objects (not of substantial significance to users) (#100)
+* Fixed bug where custom color functions (e.g. `cmap_fill_continuous()` etc) did not allow for passing other arguments on to ggplot2's `scale` functions (#102 #103)
+* modified `finalize_plot()` to accept `title_width = 0` without causing a fuss. This is a short-term fix, with more improvements coming. (#107)
+* In `cmapplot_globals$consts`, eliminated `margin_title_r`, which created space between the title/caption and plotbox inside the title column. Replaced it  with `margin_plot_l`, which creates the same buffer but does so in the plot column, not the title column. This was necessary to keep an active lefthand margin in situations where `title_width = 0`. (#107)
+
+(This list does not include documentation changes.)
+
+## Backward compatibility notes
+Users who have written code with previous versions of cmapplot should note these known compatibility issues:
+* `margin_title_r` no longer exists. Code that overrides this in `finalize_plot()` should not error, but will also have no effect on your plot. Change to `margin_plot_l`.
+* Titles and captions will be a bit wider (the width of the title and caption grobs are no longer modified by `margin_title_r`)
+* Plots will be a bit narrower (the width of the plotbox is now modified by `margin_plot_l`)
+
+
+# cmapplot 1.0.0
+December 1, 2020
+
+* initial package release 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,3 @@
-# cmapplot 1.1.1
-February 22, 2020
-
-* Creates `NEWS.md` file and adds to pkgdown website.  
-
 # cmapplot 1.1.0
 February 22, 2020
 
@@ -11,8 +6,9 @@ This update primarily makes many changes to `finalize_plot()` to enable printing
 
 * setting `title_width = 0` now has the effect of eliminating the title and shifting the caption from the title column to directly below the plot
 * There is a new argument, `caption_align`, which takes numeric range 0 to 1. `0`, the default, aligns the caption bottom or left (in title-column and below-plot captions, respectively). `1` aligns the caption top or right. `0.5` centers. The argument `caption_valign` has been deprecated.
+* Separately, this version also creates this `NEWS.md` file for the pkgdown website.  
 
-Under-the-hood changes are documented in PR #111, specifically [here](https://github.com/CMAP-REPOS/cmapplot/pull/111#issuecomment-782779446). 
+Under-the-hood changes to `finalize_plot()` are documented in PR #111, specifically [here](https://github.com/CMAP-REPOS/cmapplot/pull/111#issuecomment-782779446). 
 
 ## Backward compatibility notes
 Users who have written code with previous versions of cmapplot should note these known compatibility issues:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # cmapplot 1.1.0
-February 22, 2020
+PR #111 | February 22, 2020
 
 This update primarily makes many changes to `finalize_plot()` to enable printing plots without the left-hand "title column" -- the area that contains the title and the caption. Most but not all changes are under the hood and should not impact the user. Those that will impact the user include:
 
@@ -15,16 +15,17 @@ Users who have written code with previous versions of cmapplot should note these
 * In `finalize_plot()`, the argument `caption_valign` has been deprecated and will now issue a message alert (but will still work, for now). Please update your code to ues the new argument `caption_align`. 
 
 
+# cmapplot 1.0.4
+PR #110 | February 3, 2020
+
+* The ggplot2 geom `geom_label` is now added to the list of geoms for which text aesthetics are automatically updated to CMAP style (ie to Whitney fonts). Previously, only `geom_text` and the custom `geom_text_last` were available in CMAP style. 
+
+
 # cmapplot 1.0.3
-February 2, 2020
+PR #107 | February 2, 2020
 
-* Improvement of tickmark handling via addition of `axisticks`  argument in `theme_cmap()` (#100)
-* Substantial backend simplification of how `theme_cmap()` generates theme objects (not of substantial significance to users) (#100)
-* Fixed bug where custom color functions (e.g. `cmap_fill_continuous()` etc) did not allow for passing other arguments on to ggplot2's `scale` functions (#102 #103)
-* modified `finalize_plot()` to accept `title_width = 0` without causing a fuss. This is a short-term fix, with more improvements coming. (#107)
-* In `cmapplot_globals$consts`, eliminated `margin_title_r`, which created space between the title/caption and plotbox inside the title column. Replaced it  with `margin_plot_l`, which creates the same buffer but does so in the plot column, not the title column. This was necessary to keep an active lefthand margin in situations where `title_width = 0`. (#107)
-
-(This list does not include documentation changes.)
+* modified `finalize_plot()` to accept `title_width = 0` without causing a fuss. This is a short-term fix, with more improvements coming.
+* In `cmapplot_globals$consts`, eliminated `margin_title_r`, which created space between the title/caption and plotbox inside the title column. Replaced it  with `margin_plot_l`, which creates the same buffer but does so in the plot column, not the title column. This was necessary to keep an active left-hand margin in situations where `title_width = 0`.
 
 ### Backward compatibility notes
 Users who have written code with previous versions of cmapplot should note these known compatibility issues:
@@ -32,6 +33,18 @@ Users who have written code with previous versions of cmapplot should note these
 * Titles and captions will be a bit wider (the width of the title and caption grobs are no longer modified by `margin_title_r`)
 * Plots will be a bit narrower (the width of the plotbox is now modified by `margin_plot_l`)
 
+
+# cmapplot 1.0.2
+PR #103 | January 11, 2021
+
+* Fixed bug where custom color functions (e.g. `cmap_fill_continuous()` etc) did not allow for passing other arguments on to ggplot2's `scale` functions (see issue #102)
+
+
+# cmapplot 1.0.1
+PR #100 | December 9, 2020
+
+* Improvement of tickmark handling via addition of `axisticks`  argument in `theme_cmap()` and new `length_ticks` default value in `cmapplot_globals$consts`
+* Substantial backend simplification of how `theme_cmap()` generates theme objects (not of substantial significance to users)
 
 # cmapplot 1.0.0
 December 1, 2020

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # cmapplot 1.1.0
 February 22, 2020
 
-## Changelog
 This update primarily makes many changes to `finalize_plot()` to enable printing plots without the left-hand "title column" -- the area that contains the title and the caption. Most but not all changes are under the hood and should not impact the user. Those that will impact the user include:
 
 * setting `title_width = 0` now has the effect of eliminating the title and shifting the caption from the title column to directly below the plot
@@ -10,7 +9,7 @@ This update primarily makes many changes to `finalize_plot()` to enable printing
 
 Under-the-hood changes to `finalize_plot()` are documented in PR #111, specifically [here](https://github.com/CMAP-REPOS/cmapplot/pull/111#issuecomment-782779446). 
 
-## Backward compatibility notes
+### Backward compatibility notes
 Users who have written code with previous versions of cmapplot should note these known compatibility issues:
 
 * In `finalize_plot()`, the argument `caption_valign` has been deprecated and will now issue a message alert (but will still work, for now). Please update your code to ues the new argument `caption_align`. 
@@ -19,7 +18,6 @@ Users who have written code with previous versions of cmapplot should note these
 # cmapplot 1.0.3
 February 2, 2020
 
-## Changelog
 * Improvement of tickmark handling via addition of `axisticks`  argument in `theme_cmap()` (#100)
 * Substantial backend simplification of how `theme_cmap()` generates theme objects (not of substantial significance to users) (#100)
 * Fixed bug where custom color functions (e.g. `cmap_fill_continuous()` etc) did not allow for passing other arguments on to ggplot2's `scale` functions (#102 #103)
@@ -28,7 +26,7 @@ February 2, 2020
 
 (This list does not include documentation changes.)
 
-## Backward compatibility notes
+### Backward compatibility notes
 Users who have written code with previous versions of cmapplot should note these known compatibility issues:
 * `margin_title_r` no longer exists. Code that overrides this in `finalize_plot()` should not error, but will also have no effect on your plot. Change to `margin_plot_l`.
 * Titles and captions will be a bit wider (the width of the title and caption grobs are no longer modified by `margin_title_r`)
@@ -39,3 +37,5 @@ Users who have written code with previous versions of cmapplot should note these
 December 1, 2020
 
 * initial package release 
+
+


### PR DESCRIPTION
Addressing issue #99, this adds a `NEWS.md` page. pkgdown should automatically pick this up and add it to the website as a top-line header. 

I created NEWS with `usethis::use_news_md()` , added old release data to it, then advanced the version number and automatically created a new header in NEWS for the new version number using `usethis::use_version()`. 

At the moment, this is set to merge into vertical-layout-2 branch (PR #111), so that changes appear minimal. If this looks good, we can do that, or merge this into master after. 

Note that this does not advance version number beyond 1.1.0 -- I'm considering this a part of that release.