### PR TITLE
Vignettes and mans

### DIFF
--- a/R/finalize_plot.R
+++ b/R/finalize_plot.R
@@ -96,7 +96,7 @@
 #'                mode = "window",
 #'                height = 6,
 #'                width = 8,
-#'                title_width = 2.5,
+#'                sidebar_width = 2.5,
 #'                overrides = list(margin_plot_r = 30))
 #'
 #' transit_plot <- transit_ridership %>%

--- a/R/geom_recessions.R
+++ b/R/geom_recessions.R
@@ -28,12 +28,14 @@
 #'@param rect_aes,text_aes Named list, additional aesthetics to send to the
 #'  rectangle and text geoms, respectively.
 #'@param update_recessions Logical or data frame. \code{FALSE}, the default,
-#'  relies on the package's built in recessions table. \code{TRUE} calls the
-#'  function \code{update_recessions}, which attempts to fetch the current
-#'  recessions table from the NBER website. A custom data table of recessions
-#'  can also be passed to this argument, but it must be structured identically
-#'  to the five-column data table described in the the documentation file for
-#'  the function \code{update_recessions}.
+#'  relies on the package's built in recessions table, which was last updated in
+#'  March 2021 and is loaded into the \code{sysdata.R} file located in the
+#'  \code{R} directory. \code{TRUE} calls the function
+#'  \code{update_recessions}, which attempts to fetch the current recessions
+#'  table from the NBER website. A custom data table of recessions can also be
+#'  passed to this argument, but it must be structured identically to the
+#'  five-column data table described in the the documentation file for the
+#'  function \code{update_recessions}.
 #'@param show_ongoing Logical. \code{TRUE}, the default, will display an ongoing
 #'  recession that does not yet have a defined end date. If an ongoing recession
 #'  exists, it will be displayed as extending through the maximum extent of the
@@ -62,6 +64,7 @@
 #'  \code{rect_aes = list(alpha = 0.5)}. Color and alpha were calculated using
 #'  the hints found here:
 #'  \url{https://stackoverflow.com/questions/6672374/convert-rgb-to-rgba-over-white}.
+#'
 #'
 #'@section Under the hood: This function calls two custom geoms, constructed
 #'  with ggproto. The custom GeomRecessions and GeomRecessionsText are modified

--- a/man/finalize_plot.Rd
+++ b/man/finalize_plot.Rd
@@ -137,7 +137,7 @@ finalize_plot(econ_plot,
                mode = "window",
                height = 6,
                width = 8,
-               title_width = 2.5,
+               sidebar_width = 2.5,
                overrides = list(margin_plot_r = 30))
 
 transit_plot <- transit_ridership \%>\%

--- a/man/geom_recessions.Rd
+++ b/man/geom_recessions.Rd
@@ -54,12 +54,14 @@ Defaults to \code{FALSE}.}
 rectangle and text geoms, respectively.}
 
 \item{update_recessions}{Logical or data frame. \code{FALSE}, the default,
-relies on the package's built in recessions table. \code{TRUE} calls the
-function \code{update_recessions}, which attempts to fetch the current
-recessions table from the NBER website. A custom data table of recessions
-can also be passed to this argument, but it must be structured identically
-to the five-column data table described in the the documentation file for
-the function \code{update_recessions}.}
+relies on the package's built in recessions table, which was last updated in
+March 2021 and is loaded into the \code{sysdata.R} file located in the
+\code{R} directory. \code{TRUE} calls the function
+\code{update_recessions}, which attempts to fetch the current recessions
+table from the NBER website. A custom data table of recessions can also be
+passed to this argument, but it must be structured identically to the
+five-column data table described in the the documentation file for the
+function \code{update_recessions}.}
 
 \item{show_ongoing}{Logical. \code{TRUE}, the default, will display an ongoing
 recession that does not yet have a defined end date. If an ongoing recession

--- a/vignettes/cookbook.Rmd
+++ b/vignettes/cookbook.Rmd
@@ -91,7 +91,7 @@ finalize_plot(
   
   # Tweak plot layout
   height = 4.5,
-  title_width = 2.6,
+  sidebar_width = 2.6,
   overrides = list(
     margin_plot_r = 0,  # Eliminate distance btwn plot and right side of image
     margin_legend_b = 25  # Larger than usual gap between legend and plot
@@ -398,7 +398,7 @@ finalize_plot(
     (as of August 19, 2020).",
     # Note that we used two "<br>" tags to create a line break and empty line 
     #  between sources and notes.
-  title_width = 2.4,  # Manually specify title width
+  sidebar_width = 2.4,  # Manually specify sidebar width
   overrides = list(margin_legend_b = 50)  # Increase margin below legend
 )
 ```
@@ -621,7 +621,7 @@ finalize_plot(
   plot = p,
   title = "Regional emissions by sector, 2015",
   caption = "Source: Chicago Metropolitan Agency for Planning.",
-  caption_valign = "top")
+  caption_align = 1)
 ```
 
 #### Original graphic

--- a/vignettes/plots.Rmd
+++ b/vignettes/plots.Rmd
@@ -126,6 +126,8 @@ The function `geom_recessions()`, allows for the addition of rectangles (and tex
 
 `ggplot()` always draws geoms *on top* of base plot elements like gridlines. The default fill and alpha values for `geom_recessions()` are the most transparent way possible to achieve CMAP palette color `#002d49` when drawn on a white background — thus impacting the color of the gridlines as little as possible. 
 
+Unless otherwise specified, this function relies on the National Bureau of Economic Research's definitions of recessions (see the `geom_recessions()` for more details on how to update that data or replace it with your own). If the NBER has announced the beginning of a recession but not yet declared its end (as is the case in March 2021), the function will default to displaying this ongoing recession from its beginning through the end of the visualized data. If this is not desired (for example, if the visualization is of a projection far into the future), users can remove this ongoing recession by setting `show_ongoing = FALSE`.
+
 ```{r recessions, message = FALSE}
 q <- ggplot(data = df, 
             mapping = aes(x = year, y = ridership, color = system)) +

--- a/vignettes/plots.Rmd
+++ b/vignettes/plots.Rmd
@@ -126,7 +126,7 @@ The function `geom_recessions()`, allows for the addition of rectangles (and tex
 
 `ggplot()` always draws geoms *on top* of base plot elements like gridlines. The default fill and alpha values for `geom_recessions()` are the most transparent way possible to achieve CMAP palette color `#002d49` when drawn on a white background — thus impacting the color of the gridlines as little as possible. 
 
-Unless otherwise specified, this function relies on the National Bureau of Economic Research's definitions of recessions (see the `geom_recessions()` for more details on how to update that data or replace it with your own). If the NBER has announced the beginning of a recession but not yet declared its end (as is the case in March 2021), the function will default to displaying this ongoing recession from its beginning through the end of the visualized data. If this is not desired (for example, if the visualization is of a projection far into the future), users can remove this ongoing recession by setting `show_ongoing = FALSE`.
+This function relies on the National Bureau of Economic Research's definitions of recessions. Details on how to update these dates, as well as how to provide your own, can be found in `geom_recessions()` and `update_recessions()`. If the most recent recession has not yet been declared over (as is the case in March 2021), the function will default to displaying this ongoing recession from its beginning through the end of the visualized data. If this is not desired (for example, if the visualization is of a projection far into the future), users can remove this ongoing recession by setting `show_ongoing = FALSE`. 
 
 ```{r recessions, message = FALSE}
 q <- ggplot(data = df, 


### PR DESCRIPTION
This PR includes a few small tweaks to the documentation and vignettes, including removing calls to deprecated arguments `caption_valign` and `title_width`. It also adds a paragraph to the `finalize` vignette explaining the behavior of ongoing recessions and adding some links that reference the idea of updating and replacing the recessions tables, and notes the current location of the recessions table.