### PR TITLE
Allow for discrete versions of gradients

### DIFF
--- a/R/colors_continuous.R
+++ b/R/colors_continuous.R
@@ -141,19 +141,36 @@ mid_rescaler2 <- function(mid) {
 #' @export
 cmap_fill_continuous <- function(palette = "seq_reds",
                                  reverse = FALSE,
+                                 discrete = FALSE,
                                  middle = 0,
                                  ...) {
     if (substr(palette,1,3) == "div") {
-        ggplot2::scale_fill_gradientn(
-            colours = cmap_pal_continuous(palette, reverse = reverse)(256),
-            rescaler = mid_rescaler2(middle),
-            ...
-        )
+        if (discrete) {
+            ggplot2::discrete_scale(
+                "fill", "cmap_palettes",
+                palette = cmap_pal_discrete(palette, reverse = reverse),
+                ...
+            )
+        } else {
+            ggplot2::scale_fill_gradientn(
+                colours = cmap_pal_continuous(palette, reverse = reverse)(256),
+                rescaler = mid_rescaler2(middle),
+                ...
+                )
+        }
     } else {
-        ggplot2::scale_fill_gradientn(
-            colours = cmap_pal_continuous(palette, reverse = reverse)(256),
-            ...
-        )
+        if (discrete) {
+            ggplot2::discrete_scale(
+                "fill", "cmap_palettes",
+                palette = cmap_pal_discrete(palette, reverse = reverse),
+                ...
+            )
+        } else {
+            ggplot2::scale_fill_gradientn(
+                colours = cmap_pal_continuous(palette, reverse = reverse)(256),
+                ...
+                )
+        }
     }
 }
 

--- a/R/colors_continuous.R
+++ b/R/colors_continuous.R
@@ -141,36 +141,19 @@ mid_rescaler2 <- function(mid) {
 #' @export
 cmap_fill_continuous <- function(palette = "seq_reds",
                                  reverse = FALSE,
-                                 discrete = FALSE,
                                  middle = 0,
                                  ...) {
     if (substr(palette,1,3) == "div") {
-        if (discrete) {
-            ggplot2::discrete_scale(
-                "fill", "cmap_palettes",
-                palette = cmap_pal_discrete(palette, reverse = reverse),
-                ...
-            )
-        } else {
-            ggplot2::scale_fill_gradientn(
-                colours = cmap_pal_continuous(palette, reverse = reverse)(256),
-                rescaler = mid_rescaler2(middle),
-                ...
-                )
-        }
+        ggplot2::scale_fill_gradientn(
+            colours = cmap_pal_continuous(palette, reverse = reverse)(256),
+            rescaler = mid_rescaler2(middle),
+            ...
+        )
     } else {
-        if (discrete) {
-            ggplot2::discrete_scale(
-                "fill", "cmap_palettes",
-                palette = cmap_pal_discrete(palette, reverse = reverse),
-                ...
-            )
-        } else {
-            ggplot2::scale_fill_gradientn(
-                colours = cmap_pal_continuous(palette, reverse = reverse)(256),
-                ...
-                )
-        }
+        ggplot2::scale_fill_gradientn(
+            colours = cmap_pal_continuous(palette, reverse = reverse)(256),
+            ...
+        )
     }
 }
 

--- a/R/colors_discrete.R
+++ b/R/colors_discrete.R
@@ -1,6 +1,8 @@
 #' CMAP discrete color palettes
 #'
-#' A selection of discrete color palettes from the CMAP color palette.
+#' A selection of discrete color palettes from the CMAP color palette. These
+#' include mixed color palettes and discrete versions of the gradients defined
+#' in \code{link{cmap_fill_continuous}}.
 #'
 #' @examples
 #' # Get names of available discrete palettes.
@@ -47,9 +49,8 @@ cmap_palettes <- c(
 #' @param ttl character, title to be displayed (the name of the palette)
 #' @param num numeric, the number of colours to display
 #'
-#' @describeIn cmap_palettes Display CMAP diverging palettes. Borrowed with
-#'   respect from the \href{https://github.com/ropenscilabs/ochRe}{ochRe
-#'   package}
+#' @describeIn cmap_palettes Display CMAP palettes. Borrowed with respect from
+#'   the \href{https://github.com/ropenscilabs/ochRe}{ochRe package}
 #'
 #' @export
 viz_palette <- function(pal, ttl = deparse(substitute(pal)), num = length(pal)) {
@@ -66,7 +67,9 @@ viz_palette <- function(pal, ttl = deparse(substitute(pal)), num = length(pal)) 
 
 #' Discrete palette prep function
 #'
-#' @param palette Choose from 'cmap_palettes' list
+#' @param palette Choose from 'cmap_palettes' list, or use one of the gradients
+#'   defined in the 'cmap_gradients' list (gradients will be automatically
+#'   converted into discrete bins)
 #' @param reverse Logical; reverse color order?
 #' @param ... Additional parameters passed on to the scale type
 #'
@@ -85,7 +88,9 @@ cmap_pal_discrete <- function(palette = "prosperity", reverse = FALSE) {
 #' Pick the function depending on the aesthetic of your ggplot object (fill or
 #' color). See \code{link{cmap_palettes}} for a listing of available gradients.
 #'
-#' @param palette Choose from 'cmap_palettes' list
+#' @param palette Choose from 'cmap_palettes' list, or use one of the gradients
+#'   defined in the 'cmap_gradients' list (gradients will be automatically
+#'   converted into discrete bins)
 #' @param reverse Logical; reverse color order?
 #' @param ... Additional parameters passed on to the scale type
 #'

--- a/R/colors_discrete.R
+++ b/R/colors_discrete.R
@@ -11,30 +11,35 @@
 #' purrr::walk2(cmap_palettes, names(cmap_palettes), viz_palette)
 #'
 #' @export
-cmap_palettes <- list(
+cmap_palettes <- c(
 
-    prosperity = c("#662f00", "#e5d072", "#44008c", "#c8e572", "#c9a7ef"),
+    # Add CMAP gradients to the palettes list (note that we don't add the
+    # palettes to the gradients list since those are not sequential).
+    cmap_gradients,
 
-    community = c("#cc5f00", "#006b8c", "#e5a872", "#d2efa7", "#662f00"),
+    # Mixed color palettes
+    list(prosperity = c("#662f00", "#e5d072", "#44008c", "#c8e572", "#c9a7ef"),
 
-    environment = c("#00665c", "#b7e572", "#3f0030",  "#36d8ca", "#006b8c"),
+         community = c("#cc5f00", "#006b8c", "#e5a872", "#d2efa7", "#662f00"),
 
-    governance = c("#006b8c", "#efa7a7", "#8c4100", "#00303f", "#cca600", "#a7efe8"),
+         environment = c("#00665c", "#b7e572", "#3f0030",  "#36d8ca", "#006b8c"),
 
-    mobility = c("#8c0000", "#e5bd72", "#a7efe8", "#6d8692", "#0084ac", "#efa7a7"),
+         governance = c("#006b8c", "#efa7a7", "#8c4100", "#00303f", "#cca600", "#a7efe8"),
 
-    legislation = c("#00becc", "#cc5f00", "#3f0e00", "#cca600", "#003f8c", "#67ac00"),
+         mobility = c("#8c0000", "#e5bd72", "#a7efe8", "#6d8692", "#0084ac", "#efa7a7"),
 
-    friday = c("#00093f", "#ac8c00", "#475c66", "#e5d072", "#b5c1c8", "#006b8c"),
+         legislation = c("#00becc", "#cc5f00", "#3f0e00", "#cca600", "#003f8c", "#67ac00"),
 
-    race = c(white    = "#75a5d8",
-             black    = "#84c87e",
-             hispanic = "#d8ba39",
-             asian    = "#e77272",
-             other    = "#607b88")
+         friday = c("#00093f", "#ac8c00", "#475c66", "#e5d072", "#b5c1c8", "#006b8c"),
 
+         race = c(white    = "#75a5d8",
+                  black    = "#84c87e",
+                  hispanic = "#d8ba39",
+                  asian    = "#e77272",
+                  other    = "#607b88")
+
+    )
 )
-
 
 #' Print palette for reference
 #'

--- a/R/colors_discrete.R
+++ b/R/colors_discrete.R
@@ -45,9 +45,9 @@ cmap_palettes <- c(
 
 #' Print palette for reference
 #'
-#' @param pal character, vector of (hexadecimal) colours representing a palette
+#' @param pal character, vector of (hexadecimal) colors representing a palette
 #' @param ttl character, title to be displayed (the name of the palette)
-#' @param num numeric, the number of colours to display
+#' @param num numeric, the number of colors to display
 #'
 #' @describeIn cmap_palettes Display CMAP palettes. Borrowed with respect from
 #'   the \href{https://github.com/ropenscilabs/ochRe}{ochRe package}
@@ -59,11 +59,10 @@ viz_palette <- function(pal, ttl = deparse(substitute(pal)), num = length(pal)) 
     }
     pal_func <- grDevices::colorRampPalette(pal)
     graphics::image(seq_len(num), 1, as.matrix(seq_len(num)), col = pal_func(num),
-                    main = paste0(ttl, " (", length(pal), " colours in palette, ",
+                    main = paste0(ttl, " (", length(pal), " colors in palette, ",
                                   num, " displayed)"),
                     xlab = "", ylab = "", xaxt = "n", yaxt = "n",  bty = "n")
 }
-
 
 #' Discrete palette prep function
 #'
@@ -81,7 +80,6 @@ cmap_pal_discrete <- function(palette = "prosperity", reverse = FALSE) {
     }
     return(grDevices::colorRampPalette(pal))
 }
-
 
 #' Apply discrete CMAP palettes to ggplot2 aesthetics
 #'
@@ -118,7 +116,7 @@ cmap_fill_discrete <- function(palette = "prosperity", reverse = FALSE, ...) {
 #' @export
 cmap_color_discrete <- function(palette = "prosperity", reverse = FALSE, ...) {
     ggplot2::discrete_scale(
-        "colour", "cmap_palettes",
+        "color", "cmap_palettes",
         palette = cmap_pal_discrete(palette, reverse = reverse),
         ...
     )

--- a/R/colors_discrete.R
+++ b/R/colors_discrete.R
@@ -116,7 +116,7 @@ cmap_fill_discrete <- function(palette = "prosperity", reverse = FALSE, ...) {
 #' @export
 cmap_color_discrete <- function(palette = "prosperity", reverse = FALSE, ...) {
     ggplot2::discrete_scale(
-        "color", "cmap_palettes",
+        "colour", "cmap_palettes",
         palette = cmap_pal_discrete(palette, reverse = reverse),
         ...
     )

--- a/man/cmap_fill_discrete.Rd
+++ b/man/cmap_fill_discrete.Rd
@@ -13,7 +13,9 @@ cmap_color_discrete(palette = "prosperity", reverse = FALSE, ...)
 cmap_colour_discrete(palette = "prosperity", reverse = FALSE, ...)
 }
 \arguments{
-\item{palette}{Choose from 'cmap_palettes' list}
+\item{palette}{Choose from 'cmap_palettes' list, or use one of the gradients
+defined in the 'cmap_gradients' list (gradients will be automatically
+converted into discrete bins)}
 
 \item{reverse}{Logical; reverse color order?}
 

--- a/man/cmap_palettes.Rd
+++ b/man/cmap_palettes.Rd
@@ -14,11 +14,11 @@ cmap_palettes
 viz_palette(pal, ttl = deparse(substitute(pal)), num = length(pal))
 }
 \arguments{
-\item{pal}{character, vector of (hexadecimal) colours representing a palette}
+\item{pal}{character, vector of (hexadecimal) colors representing a palette}
 
 \item{ttl}{character, title to be displayed (the name of the palette)}
 
-\item{num}{numeric, the number of colours to display}
+\item{num}{numeric, the number of colors to display}
 }
 \description{
 A selection of discrete color palettes from the CMAP color palette. These

--- a/man/cmap_palettes.Rd
+++ b/man/cmap_palettes.Rd
@@ -6,7 +6,7 @@
 \alias{viz_palette}
 \title{CMAP discrete color palettes}
 \format{
-An object of class \code{list} of length 8.
+An object of class \code{list} of length 31.
 }
 \usage{
 cmap_palettes
@@ -21,13 +21,14 @@ viz_palette(pal, ttl = deparse(substitute(pal)), num = length(pal))
 \item{num}{numeric, the number of colours to display}
 }
 \description{
-A selection of discrete color palettes from the CMAP color palette.
+A selection of discrete color palettes from the CMAP color palette. These
+include mixed color palettes and discrete versions of the gradients defined
+in \code{link{cmap_fill_continuous}}.
 }
 \section{Functions}{
 \itemize{
-\item \code{viz_palette}: Display CMAP diverging palettes. Borrowed with
-respect from the \href{https://github.com/ropenscilabs/ochRe}{ochRe
-package}
+\item \code{viz_palette}: Display CMAP palettes. Borrowed with respect from
+the \href{https://github.com/ropenscilabs/ochRe}{ochRe package}
 }}
 
 \examples{

--- a/vignettes/colors.Rmd
+++ b/vignettes/colors.Rmd
@@ -24,24 +24,6 @@ library(cmapplot)
 
 Palettes based on the CMAP color palette can be applied directly to ggplot2 graphics. The package contains both discrete and continuous color palettes. Each type of palette can be applied to either the color or fill attributes of a ggplot.
 
-
-## Discrete palettes
-
-Add discrete palettes by adding either the `cmap_fill_discrete()` or `cmap_color_discrete()` function to your plot construction. Note that discrete palettes will automatically interpolate additional colors if the dataset has more colors than the palette. This can be helpful but is not ideal for finished graphics. See `?cmap_palettes` for displays of all discrete palettes.
-
-```{r color_discrete, message = FALSE}
-df <- dplyr::filter(grp_over_time, category == "Goods-Producing")
-
-ggplot(data = df) +
-  geom_line(mapping = aes(x = year, y = realgrp, color = cluster), 
-            size = 1.25) +
-  scale_x_continuous(breaks = seq(from = 2007, to = 2017, by = 2)) +
-  cmap_color_discrete(palette = "community", reverse = TRUE) +
-  theme_cmap() +
-  ggtitle("Real GRP of goods-producing clusters over time")
-```
-
-
 ## Continuous palettes
 
 Add continuous palettes by adding either the `cmap_fill_continuous()` or `cmap_color_continuous()` function to your plot construction. For example:
@@ -64,6 +46,23 @@ ggplot(data = df) +
 ```
 
 If you're using a divergent palette, you can specify the midpoint where the divergence begins (default is zero). See `?cmap_gradients` for displays of all continuous palettes.
+
+
+## Discrete palettes
+
+Add discrete palettes by adding either the `cmap_fill_discrete()` or `cmap_color_discrete()` function to your plot construction. Note that discrete palettes will automatically interpolate additional colors if the dataset has more colors than the palette. This can be helpful but is not ideal for finished graphics. See `?cmap_palettes` for displays of all discrete palettes. These include a set of complementary colors (e.g., the `"prosperity"` palette), but also discrete versions of the gradients defined above (e.g., a binned blue palette implemented by calling `"seq_blues"`).
+
+```{r color_discrete, message = FALSE}
+df <- dplyr::filter(grp_over_time, category == "Goods-Producing")
+
+ggplot(data = df) +
+  geom_line(mapping = aes(x = year, y = realgrp, color = cluster), 
+            size = 1.25) +
+  scale_x_continuous(breaks = seq(from = 2007, to = 2017, by = 2)) +
+  cmap_color_discrete(palette = "community", reverse = TRUE) +
+  theme_cmap() +
+  ggtitle("Real GRP of goods-producing clusters over time")
+```
 
 
 ## Race/ethnicity palette


### PR DESCRIPTION
This is a relatively simple PR - it just adds the gradients to the list of allowed color palettes for the discrete scales. I also updated the documentation and vignettes accordingly. I could be missing something, so please let me know @gritzenthaler if there's some reason why this wouldn't work in practice.

One thing I was thinking about as additional work might be to find a way to "recenter" a diverging discrete palette around some non-mid-point using factors (I can see instances where this might come up in a mapping context, i.e., you have five bins above zero and two below - the current code would center it around the 4th factor, no matter the value). However, I couldn't see an easy way to do that, since the discrete scales don't seem to have a rescaling option easily available.

Open to other thoughts - I thought at the very least this adds the requested functionality and doesn't preclude a more sophisticated approach later on.