### PR TITLE
graphics backend for positron fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmapplot
 Title: CMAP Themes and Color Palettes
-Version: 1.2.2
+Version: 1.2.3
 Authors@R: c(
     person("Daniel", "Comeaux",
            role = c("aut"),
@@ -22,6 +22,9 @@ Authors@R: c(
     person("Sean", "Connelly",
            role = c("aut", "cre"),
            email = "sconnelly@cmap.illinois.gov"),
+    person("David", "Wells",
+           role = "aut",
+           email = "dwells@cmap.illinois.gov"),
     person("Chicago Metropolitan Agency for Planning",
            role = c("cph", "fnd")))
 Description: Provides themes and color scales for 'ggplot2', based on Chicago

--- a/R/cmapplot.R
+++ b/R/cmapplot.R
@@ -110,7 +110,7 @@
     # ... and check on rstudio graphics
     if (rstudioapi::isAvailable()){
       if(rstudioapi::getVersion() > "1.4"){
-        if(getOption("RStudioGD.backend") != "ragg"){
+        if(getOption("RStudioGD.backend", FALSE) != "ragg"){
           options(RStudioGD.backend = "ragg")
           packageStartupMessage(paste(
             "cmapplot has set RStudio graphics to `ragg` for the current session.",

--- a/man/cmapplot.Rd
+++ b/man/cmapplot.Rd
@@ -36,6 +36,7 @@ Authors:
   \item Noel Peterson (\href{https://orcid.org/0000-0003-1290-2362}{ORCID})
   \item Greta Ritzenthaler
   \item Matthew Stern (\href{https://orcid.org/0000-0001-9119-2121}{ORCID})
+  \item David Wells \email{dwells@cmap.illinois.gov}
 }
 
 Other contributors:


### PR DESCRIPTION
The code that sets the RStudio graphic backend to RAGG looks for RStudio global options, which don't exist when using other IDES. The check for rstudioapi::is_available() used to in theory handle this, but Positron is also built with the rstudioapi. You can currently use cmapplot in Positron normally, but trying to build the package (for example in a golem shiny app) raises an error. This patch changes the return of getOption from NULL to FALSE which fixes the "arguement of length 0" error.